### PR TITLE
add copy_meta action

### DIFF
--- a/seismicpro/models/unet_attention.py
+++ b/seismicpro/models/unet_attention.py
@@ -36,8 +36,7 @@ class UnetAtt(EncoderDecoder):
         att = super().body(raw, name='attention', **{**kwargs, **attn_config}) # pylint: disable=not-a-mapping
         return main, att, raw, offset
 
-    @classmethod
-    def head(cls, inputs, targets, name='head', **kwargs):
+    def head(self, inputs, targets, name='head', **kwargs):
         _ = targets, name, kwargs
         main, att, raw, offset = inputs
 

--- a/seismicpro/models/unet_attention.py
+++ b/seismicpro/models/unet_attention.py
@@ -1,4 +1,5 @@
 """ UnetAttention model """
+# pylint: disable=signature-differs
 import tensorflow as tf
 
 from ..batchflow.batchflow.models.tf import EncoderDecoder

--- a/seismicpro/models/unet_attention.py
+++ b/seismicpro/models/unet_attention.py
@@ -37,7 +37,7 @@ class UnetAtt(EncoderDecoder):
         return main, att, raw, offset
 
     @classmethod
-    def head(self, inputs, targets, name='head', **kwargs):
+    def head(cls, inputs, targets, name='head', **kwargs):
         _ = targets, name, kwargs
         main, att, raw, offset = inputs
 

--- a/seismicpro/models/unet_attention.py
+++ b/seismicpro/models/unet_attention.py
@@ -1,5 +1,4 @@
 """ UnetAttention model """
-# pylint: disable=signature-differs
 import tensorflow as tf
 
 from ..batchflow.batchflow.models.tf import EncoderDecoder
@@ -20,12 +19,14 @@ class UnetAtt(EncoderDecoder):
 
         return config
 
-    def initial_block(self, inputs, *args, **kwargs):
-        _ = args, kwargs
+    @classmethod
+    def initial_block(cls, inputs, name='initial_block', **kwargs):
+        _ = name, kwargs
         return inputs
 
-    def body(self, inputs, *args, **kwargs):
-        _ = args
+    @classmethod
+    def body(cls, inputs, name='body', **kwargs):
+        _ = name
         raw, offset = inputs
 
         main_config = kwargs.pop('main')
@@ -35,8 +36,9 @@ class UnetAtt(EncoderDecoder):
         att = super().body(raw, name='attention', **{**kwargs, **attn_config}) # pylint: disable=not-a-mapping
         return main, att, raw, offset
 
-    def head(self, inputs, *args, **kwargs):
-        _ = args, kwargs
+    @classmethod
+    def head(self, inputs, targets, name='head', **kwargs):
+        _ = targets, name, kwargs
         main, att, raw, offset = inputs
 
         #Get a single channel with sigmoid activation for the attention branch

--- a/seismicpro/src/seismic_batch.py
+++ b/seismicpro/src/seismic_batch.py
@@ -284,7 +284,7 @@ class SeismicBatch(Batch):
             'new_raw': {'arg_1': 'val_1', 'arg_2': 'val_2'}}
 
 
-        Use for few components:
+        Use for several components:
             >>> batch.copy_meta(['raw', 'raw'], ['new_raw', 'new_raw_2'], key=[['arg_1'], ['arg_2']])
             >>> batch.meta
             {'raw': {'arg_1': 'val_1', 'arg_2': 'val_2', 'arg_3': 'val_3'},

--- a/seismicpro/src/seismic_batch.py
+++ b/seismicpro/src/seismic_batch.py
@@ -304,15 +304,14 @@ class SeismicBatch(Batch):
             if fr_comp not in self.meta:
                 raise ValueError(f'{fr_comp} not exist.')
 
-            added_meta = self.meta[fr_comp]
+            added_meta = self.meta[fr_comp].copy()
             if keys[ix] is not None:
                 if isinstance(keys[ix], str):
                     added_meta = {k: added_meta[k] for k in keys}
                 else:
                     added_meta = {k: added_meta[k] for k in keys[ix]}
-            new_meta = dict(added_meta)
-            new_meta.update(**self.meta[t_comp])
-            self.meta[t_comp] = new_meta
+            added_meta.update(**self.meta[t_comp])
+            self.meta[t_comp] = added_meta
 
         return self
 

--- a/seismicpro/src/seismic_batch.py
+++ b/seismicpro/src/seismic_batch.py
@@ -283,8 +283,8 @@ class SeismicBatch(Batch):
 
             if self.meta[t_comp]:
                 warnings.warn("Meta of component {} is not empty and".format(t_comp) + \
-                                " will be replaced by the meta from component {}.".format(fr_comp),
-                                UserWarning)
+                              " will be replaced by the meta from component {}.".format(fr_comp),
+                              UserWarning)
             self.meta[t_comp] = self.meta[fr_comp].copy()
 
         return self

--- a/seismicpro/src/seismic_batch.py
+++ b/seismicpro/src/seismic_batch.py
@@ -161,7 +161,7 @@ class SeismicBatch(Batch):
         if preloaded is None:
             self.meta = dict()
 
-    def _init_component(self, src, dst, *args, **kwargs):
+    def _init_component(self, *args, src, dst, **kwargs):
         """Create and preallocate a new attribute with the name ``dst`` if it
         does not exist and return batch indices."""
         _ = args, kwargs

--- a/seismicpro/src/seismic_batch.py
+++ b/seismicpro/src/seismic_batch.py
@@ -241,8 +241,8 @@ class SeismicBatch(Batch):
         return np.array(np.split(values, np.cumsum(tracecounts)[:-1]) + [None])[:-1]
 
     def copy_meta(self, from_comp, to_comp, overwrite=False):
-        """Copy meta from one component to another or form few components. One can copy either
-        full meta or only particular keys.
+        """Copy meta from one component to another or form list of components to list of
+        components with same length.
 
         Parameters
         ----------
@@ -250,21 +250,21 @@ class SeismicBatch(Batch):
             Component's name to copy meta from or list of component's names.
         to_comp : str or array-like
             Component's name to copy meta in or list of component's names.
+        overwrite : bool
+            If True, all meta from `to_comp` will be rewritten by meta from `from_comp`.
+            If False, only new meta from will be added.
 
         Raises
         ------
             ValueError : if `from_comp` and `to_comp` have different length.
             ValueError : if one of given to `from_comp` component doesn't exist.
-
-        Note
-        ----
-        The copied meta will not overwrite the old meta.
         """
         from_comp = (from_comp, ) if isinstance(from_comp, str) else from_comp
         to_comp = (to_comp, ) if isinstance(to_comp, str) else to_comp
 
         if len(from_comp) != len(to_comp):
-            raise ValueError('Length from_comp should be equal to to_comp length.')
+            raise ValueError("Unexpected length of component's lists. Given len(from_comp)="
+                              "{} != len(to_comp)={}.".format(len(to_comp), len(from_comp)))
 
         for fr_comp, t_comp in zip(from_comp, to_comp):
             if fr_comp not in self.meta:
@@ -801,8 +801,8 @@ class SeismicBatch(Batch):
             return self
 
         self._sort(src=src, sort_by=sort_by, current_sorting=current_sorting, dst=dst)
-        self.meta[dst]['sorting'] = sort_by
         self.copy_meta(src, dst)
+        self.meta[dst]['sorting'] = sort_by
         return self
 
     @action

--- a/seismicpro/src/seismic_batch.py
+++ b/seismicpro/src/seismic_batch.py
@@ -164,7 +164,7 @@ class SeismicBatch(Batch):
     def _init_component(self, src, dst, *args, **kwargs):
         """Create and preallocate a new attribute with the name ``dst`` if it
         does not exist and return batch indices."""
-        _ = args
+        _ = args, kwargs
         dst = (dst, ) if isinstance(dst, str) else dst
         copy_meta = True
 
@@ -185,6 +185,7 @@ class SeismicBatch(Batch):
                         self.meta[idst] = dict()
             else:
                 self.meta[idst] = dict()
+
             if self.components is None or idst not in self.components:
                 self.add_components(idst, init=self.array_of_nones)
 

--- a/seismicpro/src/seismic_batch.py
+++ b/seismicpro/src/seismic_batch.py
@@ -264,7 +264,7 @@ class SeismicBatch(Batch):
 
         if len(from_comp) != len(to_comp):
             raise ValueError("Unexpected length of component's lists. Given len(from_comp)="
-                              "{} != len(to_comp)={}.".format(len(to_comp), len(from_comp)))
+                             "{} != len(to_comp)={}.".format(len(to_comp), len(from_comp)))
 
         for fr_comp, t_comp in zip(from_comp, to_comp):
             if fr_comp not in self.meta:

--- a/seismicpro/src/seismic_batch.py
+++ b/seismicpro/src/seismic_batch.py
@@ -1,6 +1,5 @@
 """Seismic batch.""" # pylint: disable=too-many-lines
 import os
-import warnings
 from textwrap import dedent
 import numpy as np
 import matplotlib.pyplot as plt
@@ -264,12 +263,11 @@ class SeismicBatch(Batch):
         if len(from_comp) != len(to_comp):
             raise ValueError('Length from_comp should be equal to to_comp length.')
 
-        for ix, (fr_comp, t_comp) in enumerate(zip(from_comp, to_comp)):
+        for fr_comp, t_comp in zip(from_comp, to_comp):
             if fr_comp not in self.meta:
                 raise ValueError(f'{fr_comp} not exist.')
 
-            added_meta = self.meta[fr_comp]
-            new_meta = dict(added_meta)
+            new_meta = self.meta[fr_comp].copy()
             new_meta.update(**self.meta[t_comp])
             self.meta[t_comp] = new_meta
 

--- a/seismicpro/src/seismic_batch.py
+++ b/seismicpro/src/seismic_batch.py
@@ -280,12 +280,12 @@ class SeismicBatch(Batch):
 
             if fr_comp == t_comp:
                 continue
-            else:
-                if self.meta[t_comp]:
-                    warnings.warn("Meta of component {} is not empty and".format(t_comp) + \
-                                  " will be replaced by the meta from component {}.".format(fr_comp),
-                                  UserWarning)
-                self.meta[t_comp] = self.meta[fr_comp].copy()
+
+            if self.meta[t_comp]:
+                warnings.warn("Meta of component {} is not empty and".format(t_comp) + \
+                                " will be replaced by the meta from component {}.".format(fr_comp),
+                                UserWarning)
+            self.meta[t_comp] = self.meta[fr_comp].copy()
 
         return self
 

--- a/seismicpro/src/seismic_batch.py
+++ b/seismicpro/src/seismic_batch.py
@@ -163,14 +163,25 @@ class SeismicBatch(Batch):
     def _init_component(self, *args, dst, **kwargs):
         """Create and preallocate a new attribute with the name ``dst`` if it
         does not exist and return batch indices."""
-        _ = args, kwargs
+        _ = args
+        src = kwargs.get('src')
         dst = (dst, ) if isinstance(dst, str) else dst
 
-        for comp in dst:
-            self.meta[comp] = self.meta[comp] if comp in self.meta else dict()
+        if isinstance(src, str):
+            src = (src, ) * len(dst)
+        elif len(dst) != len(src):
+            raise ValueError(f'Length of src and dst should be equal. Now is len(src)={len(src)}, '\
+                             f'len(dst)={len(dst)}')
 
-            if self.components is None or comp not in self.components:
-                self.add_components(comp, init=self.array_of_nones)
+        for comp_from, comp_to in zip(src, dst):
+            if comp_to not in self.meta:
+                if comp_from in self.meta:
+                    self.meta[comp_to] = self.meta[comp_from].copy()
+                else:
+                    self.meta[comp_to] = dict()
+
+            if self.components is None or comp_to not in self.components:
+                self.add_components(comp_to, init=self.array_of_nones)
 
         return self.indices
 
@@ -239,81 +250,6 @@ class SeismicBatch(Batch):
             return values
 
         return np.array(np.split(values, np.cumsum(tracecounts)[:-1]) + [None])[:-1]
-
-    @action
-    def copy_meta(self, from_comp, to_comp, keys=None):
-        """Copy meta from one component to another or form few components. One can copy either
-        full meta or only particular keys.
-
-        Parameters
-        ----------
-        from_comp : str or array-like
-            Component's name to copy meta from or list of component's names.
-        to_comp : str or array-like
-            Component's name to copy meta in or list of component's names.
-        keys : str, array-like or None, optional
-            if None, all meta will be copied
-            if str, only meta[keys] will be copied
-            if array-like,
-                if 1d array-like, for each `to_comp` will be used same keys
-                if 2d array-like, for each `to_comp` will be used particular keys.
-                It means that i-th component will contain only `keys[i]` elements from meta.
-
-        Raises
-        ------
-        ValueError : if `from_comp` and `to_comp` have different length.
-        ValueError : if one of given to `from_comp` component doesn't exist.
-
-        Note
-        ----
-            The copied meta will not overwrite the old meta.
-
-        Examples
-        --------
-        Use all meta:
-            >>> batch.copy_meta('raw', 'new_raw')
-            >>> batch.meta
-            {'raw': {'arg_1': 'val_1', 'arg_2': 'val_2', 'arg_3': 'val_3'},
-            'new_raw': {'arg_1': 'val_1', 'arg_2': 'val_2', 'arg_3': 'val_3'}}
-
-
-        Copy two values:
-            >>> batch.copy_meta('raw', 'new_raw', key=['arg_1', 'arg_2'])
-            >>> batch.meta
-            {'raw': {'arg_1': 'val_1', 'arg_2': 'val_2', 'arg_3': 'val_3'},
-            'new_raw': {'arg_1': 'val_1', 'arg_2': 'val_2'}}
-
-
-        Use for several components:
-            >>> batch.copy_meta(['raw', 'raw'], ['new_raw', 'new_raw_2'], key=[['arg_1'], ['arg_2']])
-            >>> batch.meta
-            {'raw': {'arg_1': 'val_1', 'arg_2': 'val_2', 'arg_3': 'val_3'},
-            'new_raw': {'arg_1': 'val_1'},
-            'new_raw': {'arg_2': 'val_2'}}
-        """
-        from_comp = (from_comp, ) if isinstance(from_comp, str) else from_comp
-        to_comp = (to_comp, ) if isinstance(to_comp, str) else to_comp
-
-        if len(from_comp) != len(to_comp):
-            raise ValueError('Length from_comp should be equal to to_comp length.')
-
-        if isinstance(keys, str) or keys is None:
-            keys = (keys, ) * len(from_comp)
-
-        for ix, (fr_comp, t_comp) in enumerate(zip(from_comp, to_comp)):
-            if fr_comp not in self.meta:
-                raise ValueError(f'{fr_comp} not exist.')
-
-            added_meta = self.meta[fr_comp].copy()
-            if keys[ix] is not None:
-                if isinstance(keys[ix], str):
-                    added_meta = {k: added_meta[k] for k in keys}
-                else:
-                    added_meta = {k: added_meta[k] for k in keys[ix]}
-            added_meta.update(**self.meta[t_comp])
-            self.meta[t_comp] = added_meta
-
-        return self
 
     @action
     @inbatch_parallel(init="_init_component", target="threads")

--- a/seismicpro/src/seismic_batch.py
+++ b/seismicpro/src/seismic_batch.py
@@ -248,9 +248,9 @@ class SeismicBatch(Batch):
         Parameters
         ----------
         from_comp : str or array-like
-            Component's name to copy meta from or list of component's names.
+            Component's name to copy meta from or list with names of components.
         to_comp : str or array-like
-            Component's name to copy meta in or list of component's names.
+            Component's name to copy meta in or list with names of components.
 
         Raises
         ------

--- a/seismicpro/src/seismic_batch.py
+++ b/seismicpro/src/seismic_batch.py
@@ -190,8 +190,8 @@ class SeismicBatch(Batch):
 
         Note
         ----
-        Batch items in each component should be filtered in decorated action.
-        This post function creates new instance of SeismicBatch with new index
+        1. Batch items in each component should be filtered in decorated action.
+        2. This post function creates new instance of SeismicBatch with new index
         instance and copies filtered components from original batch for elements
         in new index.
         """
@@ -243,19 +243,22 @@ class SeismicBatch(Batch):
     def copy_meta(self, from_comp, to_comp):
         """Copy meta from one component to another or form few components. One can copy either
         full meta or only particular keys.
+
         Parameters
         ----------
         from_comp : str or array-like
             Component's name to copy meta from or list of component's names.
         to_comp : str or array-like
             Component's name to copy meta in or list of component's names.
+
         Raises
         ------
             ValueError : if `from_comp` and `to_comp` have different length.
             ValueError : if one of given to `from_comp` component doesn't exist.
+
         Note
         ----
-            The copied meta will not overwrite the old meta.
+        The copied meta will not overwrite the old meta.
         """
         from_comp = (from_comp, ) if isinstance(from_comp, str) else from_comp
         to_comp = (to_comp, ) if isinstance(to_comp, str) else to_comp
@@ -680,6 +683,10 @@ class SeismicBatch(Batch):
         -------
         batch : SeismicBatch
             Batch with sliced traces.
+
+        Note
+        ----
+        This action copies all meta from `src` component to `dst` component.
         """
         _ = args
         pos = self.get_pos(None, src, index)
@@ -708,6 +715,10 @@ class SeismicBatch(Batch):
         -------
         batch : SeismicBatch
             Batch with padded traces.
+
+        Note
+        ----
+        This action copies all meta from `src` component to `dst` component.
         """
         _ = args
         pos = self.get_pos(None, src, index)
@@ -772,6 +783,11 @@ class SeismicBatch(Batch):
         -------
         batch : SeismicBatch
             Batch with new trace sorting.
+
+        Note
+        ----
+        1. This action copies all meta from `src` component to `dst` component.
+        2. `dst` meta contains sorting type in `meta['sorting']`.
         """
         _ = args
         if src in self.meta.keys():
@@ -890,14 +906,15 @@ class SeismicBatch(Batch):
             : SeismicBatch
             Traces straightened on the basis of speed and time values.
 
+        Raises
+        ------
+        ValueError : Raise if traces are not sorted by offset.
+
         Note
         ----
         1. Works only with sorted traces by offset.
         2. Works properly only with CustomIndex with CDP index.
-
-        Raises
-        ------
-        ValueError : Raise if traces are not sorted by offset.
+        3. This action copies all meta from `src` component to `dst` component.
         """
         if not isinstance(self.index, CustomIndex):
             raise ValueError("Index must be CustomIndex, not {}".format(type(self.index)))
@@ -987,14 +1004,15 @@ class SeismicBatch(Batch):
             : SeismicBatch
             Batch of shot gathers with corrected spherical divergence.
 
-        Note
-        ----
-        Works properly only with FieldIndex.
-
         Raises
         ------
         ValueError : If Index is not FieldIndex.
         ValueError : If length of ```params``` not equal to 2.
+
+        Note
+        ----
+        1. Works properly only with FieldIndex.
+        2. This action copies all meta from `src` component to `dst` component.
         """
         if not isinstance(self.index, FieldIndex):
             raise ValueError("Index must be FieldIndex, not {}".format(type(self.index)))
@@ -1224,6 +1242,10 @@ class SeismicBatch(Batch):
         -------
         batch : SeismicBatch
             Batch with the standardized traces.
+
+        Note
+        ----
+        This action copies all meta from `src` component to `dst` component.
         """
         data = np.concatenate(getattr(self, src))
         std_data = (data - np.mean(data, axis=1, keepdims=True)) / (np.std(data, axis=1, keepdims=True) + 10 ** -6)
@@ -1405,10 +1427,11 @@ class SeismicBatch(Batch):
 
         Note
         ----
-        Works properly only with FieldIndex.
-        If `params` dict is user-defined, `survey_id_col` should be
+        1. Works properly only with FieldIndex.
+        2. If `params` dict is user-defined, `survey_id_col` should be
         provided excplicitly either as argument, or as `params` dict key-value
         pair.
+        3. This action copies all meta from `src` component to `dst` component.
         """
         if not isinstance(self.index, FieldIndex):
             raise ValueError("Index must be FieldIndex, not {}".format(type(self.index)))
@@ -1495,8 +1518,8 @@ class SeismicBatch(Batch):
 
         Notes
         -----
-        - Works properly only with FieldIndex.
-        - `R` samples a relative position of top-left coordinate in a feasible region of seismogram.
+        1. Works properly only with FieldIndex.
+        2. `R` samples a relative position of top-left coordinate in a feasible region of seismogram.
 
         Examples
         --------
@@ -1543,7 +1566,6 @@ class SeismicBatch(Batch):
         threshold: float
             Threshold determining amplitude, such that all the samples with amplitude less then threshold would be
             skipped. Introduced because of unstable behaviour of the hilbert transform at the begining of the signal.
-
          """
         shift *= np.pi
         pos = self.get_pos(None, src, index)

--- a/seismicpro/src/seismic_batch.py
+++ b/seismicpro/src/seismic_batch.py
@@ -241,7 +241,7 @@ class SeismicBatch(Batch):
         return np.array(np.split(values, np.cumsum(tracecounts)[:-1]) + [None])[:-1]
 
     def copy_meta(self, from_comp, to_comp, overwrite):
-        """Copy meta from one component to another or form list of components to list of
+        """Copy meta from one component to another or from list of components to list of
         components with same length.
 
         Parameters

--- a/seismicpro/src/seismic_batch.py
+++ b/seismicpro/src/seismic_batch.py
@@ -268,7 +268,7 @@ class SeismicBatch(Batch):
 
         for fr_comp, t_comp in zip(from_comp, to_comp):
             if fr_comp not in self.meta:
-                raise ValueError(f'{fr_comp} not exist.')
+                raise ValueError('{} does not exist.'.format(fr_comp))
             if overwrite:
                 self.meta[t_comp].update(**self.meta[fr_comp])
             else:

--- a/seismicpro/src/seismic_batch.py
+++ b/seismicpro/src/seismic_batch.py
@@ -808,7 +808,7 @@ class SeismicBatch(Batch):
 
     @action
     @inbatch_parallel(init="indices", post='_post_filter_by_mask', target="threads")
-    def drop_zero_traces(self, index, src, num_zero, all_comps_sorted=True, **kwargs):
+    def drop_zero_traces(self, index, src, num_zero, all_comps_sorted=True):
         """Drop traces with sequence of zeros longer than ```num_zero```.
 
         This action drops traces from index dataframe and from all batch components
@@ -840,7 +840,6 @@ class SeismicBatch(Batch):
         This action creates new instance of SeismicBatch with new index
         instance.
         """
-        _ = kwargs
         sorting = self.meta[src]['sorting']
         if sorting is None and not isinstance(self.index, TraceIndex):
             raise ValueError('traces in `{}` component should be sorted '

--- a/seismicpro/src/seismic_batch.py
+++ b/seismicpro/src/seismic_batch.py
@@ -240,7 +240,7 @@ class SeismicBatch(Batch):
 
         return np.array(np.split(values, np.cumsum(tracecounts)[:-1]) + [None])[:-1]
 
-    def copy_meta(self, from_comp, to_comp):
+    def copy_meta(self, from_comp, to_comp, overwrite=False):
         """Copy meta from one component to another or form few components. One can copy either
         full meta or only particular keys.
 
@@ -269,10 +269,12 @@ class SeismicBatch(Batch):
         for fr_comp, t_comp in zip(from_comp, to_comp):
             if fr_comp not in self.meta:
                 raise ValueError(f'{fr_comp} not exist.')
-
-            new_meta = self.meta[fr_comp].copy()
-            new_meta.update(**self.meta[t_comp])
-            self.meta[t_comp] = new_meta
+            if overwrite:
+                self.meta[t_comp].update(**self.meta[fr_comp])
+            else:
+                new_meta = self.meta[fr_comp].copy()
+                new_meta.update(**self.meta[t_comp])
+                self.meta[t_comp] = new_meta
 
         return self
 


### PR DESCRIPTION
This pull request is aimed to add an oppotunity to copy meta information from one component to another. Only one action `copy_meta` contains here.

We need this because there are actions that use meta data inside:
* _dump_split_segy
* _dump_picking
* hodograph_straightening
* calculate_semblance

Without coping meta we aren't able to use them with any components, we can use them only will component with loaded data inside (usually 'raw').