### PR TITLE
Fix bug in meta

### DIFF
--- a/seismicpro/src/seismic_batch.py
+++ b/seismicpro/src/seismic_batch.py
@@ -247,7 +247,7 @@ class SeismicBatch(Batch):
         return self
 
     def update_component(self, component, value):
-        """ Add new component or update existed one
+        """ Add a new component or update an existing one
 
         Parameters
         ----------
@@ -301,7 +301,7 @@ class SeismicBatch(Batch):
             if fr_comp == t_comp:
                 continue
 
-            if t_comp in self.meta and self.meta[t_comp] != dict():
+            if self.meta.get(t_comp):
                 warnings.warn("Meta of the component {} is not empty and".format(t_comp) + \
                               " will be replaced by the meta from the component {}.".format(fr_comp),
                               UserWarning)

--- a/seismicpro/src/seismic_batch.py
+++ b/seismicpro/src/seismic_batch.py
@@ -313,8 +313,8 @@ class SeismicBatch(Batch):
             else:
                 self.components = self.components + tuple([comp])
             setattr(self, comp, value)
-
-            self.meta[comp] = dict()
+            if comp not in self.meta:
+                self.meta[comp] = dict()
 
     def update_component(self, component, value):
         """ Add new component or update existed one

--- a/seismicpro/src/seismic_batch.py
+++ b/seismicpro/src/seismic_batch.py
@@ -262,9 +262,9 @@ class SeismicBatch(Batch):
             if fr_comp == t_comp:
                 continue
 
-            if self.meta[t_comp]:
-                warnings.warn("Meta of component {} is not empty and".format(t_comp) + \
-                              " will be replaced by the meta from component {}.".format(fr_comp),
+            if t_comp in self.meta:
+                warnings.warn("Meta of the component {} is not empty and".format(t_comp) + \
+                              " will be replaced by the meta from the component {}.".format(fr_comp),
                               UserWarning)
             self.meta[t_comp] = self.meta[fr_comp].copy()
         return self


### PR DESCRIPTION
If you create component by hands it wound't have a meta at all. Old `copy_meta` always is tried to find new component in meta and fails if the component is not contained in the meta dict.

Moreover, this PR is added  empty meta for components that was created by `add_components` action.