### PR TITLE
Fix plotters

### DIFF
--- a/seismicpro/src/plot_utils.py
+++ b/seismicpro/src/plot_utils.py
@@ -51,6 +51,13 @@ def scatter_on_top(ax, attribute):
     top_subax.set_xticks([])
     top_subax.yaxis.tick_right()
 
+def scatter_within(ax, points, **scatter_within_kwargs):
+    if np.isscalar(points[0]):
+        points = (points, )
+
+    for ipts in points:
+        ax.scatter(range(len(ipts)), ipts, **scatter_within_kwargs)
+
 def seismic_plot(arrs, wiggle=False, xlim=None, ylim=None, std=1, # pylint: disable=too-many-branches, too-many-arguments
                  pts=None, s=None, scatter_color=None, names=None, figsize=(7, 4),
                  save_to=None, dpi=None, line_color=None, title=None, 
@@ -146,6 +153,9 @@ def seismic_plot(arrs, wiggle=False, xlim=None, ylim=None, std=1, # pylint: disa
             if attribute is not None:
                 scatter_on_top(ax, attribute.flatten()[i])
 
+            if pts is not None:
+                scatter_within(ax, pts[i])
+
         elif arr.ndim == 1:
             ax.plot(arr, **kwargs)
         else:
@@ -161,9 +171,6 @@ def seismic_plot(arrs, wiggle=False, xlim=None, ylim=None, std=1, # pylint: disa
 
         if arr.ndim == 1:
             plt.xlim(xlim_curr)
-
-        if pts is not None:
-            ax.scatter(*pts, s=s, c=scatter_color)
 
     if title is not None:
         fig.suptitle(title)

--- a/seismicpro/src/plot_utils.py
+++ b/seismicpro/src/plot_utils.py
@@ -3,7 +3,7 @@ import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
 from matplotlib import patches
-from matplotlib.ticker import ScalarFormatter, AutoLocator, IndexFormatter
+from matplotlib.ticker import ScalarFormatter, AutoLocator, IndexFormatter, LinearLocator, FixedFormatter
 from matplotlib import patches, colors as mcolors
 
 from .utils import measure_gain_amplitude
@@ -525,6 +525,18 @@ def plot_metrics_map(metrics_map, cmap=None, title=None, figsize=(10, 7), # pyli
     _set_ticks(ax=ax, img_shape=metrics_map.T.shape, ticks_range_x=ticks_range_x,
                ticks_range_y=ticks_range_y, x_ticks=x_ticks, y_ticks=y_ticks,
                fontsize=fontsize)
+
+    # Block bellow does the same as _set_ticks() above
+    # x_ticker = {
+    #     'locator': LinearLocator(x_ticks),
+    #     'formatter': FixedFormatter(np.linspace(*ticks_range_x, x_ticks))
+    # }
+    
+    # y_ticker = {
+    #     'locator': LinearLocator(y_ticks),
+    #     'formatter': FixedFormatter(np.linspace(*ticks_range_y, y_ticks))
+    # }
+    # setup_tickers(ax, x_ticker, y_ticker)
 
     if save_to:
         plt.savefig(save_to, dpi=dpi, bbox_inches='tight', pad_inches=0.1)

--- a/seismicpro/src/plot_utils.py
+++ b/seismicpro/src/plot_utils.py
@@ -3,7 +3,7 @@ import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
 from matplotlib import patches
-from matplotlib.ticker import ScalarFormatter, AutoLocator
+from matplotlib.ticker import ScalarFormatter, AutoLocator, IndexFormatter
 
 from .utils import measure_gain_amplitude
 
@@ -22,13 +22,23 @@ def setup_imshow(ax, arr, **kwargs):
     ax.imshow(arr, **{**defaults, **kwargs})
 
 def setup_tickers(ax, x_ticker, y_ticker):
-    """ Setup the x / y axis tickers from the configs. In case config miss ticker - default ticker will be used. """
+    """ Setup the x / y axis tickers from the configs. 
+    In case config miss ticker - default ticker will be used.
+    In case ticker is array-like - matplotlib.ticker.IndexFormatter(ticker) will be used. """
 
-    ax.xaxis.set_major_locator(x_ticker.get('x_locator', AutoLocator()))
-    ax.yaxis.set_major_locator(y_ticker.get('y_locator', AutoLocator()))
+    def _cast_ticker(ticker):
+        if isinstance(ticker, (list, tuple, np.ndarray)):
+            return IndexFormatter(ticker)
+        else:
+            return ticker
 
-    ax.xaxis.set_major_formatter(x_ticker.get('x_formatter', ScalarFormatter()))
-    ax.yaxis.set_major_formatter(y_ticker.get('y_formatter', ScalarFormatter()))
+    x_ticker, y_ticker = [_cast_ticker(ticker) for ticker in [x_ticker, y_ticker]]
+
+    ax.xaxis.set_major_locator(x_ticker.get('locator', AutoLocator()))
+    ax.yaxis.set_major_locator(y_ticker.get('locator', AutoLocator()))
+
+    ax.xaxis.set_major_formatter(x_ticker.get('formatter', ScalarFormatter()))
+    ax.yaxis.set_major_formatter(y_ticker.get('formatter', ScalarFormatter()))
 
 def seismic_plot(arrs, wiggle=False, xlim=None, ylim=None, std=1, # pylint: disable=too-many-branches, too-many-arguments
                  pts=None, s=None, scatter_color=None, names=None, figsize=None,

--- a/seismicpro/src/plot_utils.py
+++ b/seismicpro/src/plot_utils.py
@@ -150,7 +150,7 @@ def seismic_plot(arrs, xlim=None, ylim=None, wiggle=False, std=1, # pylint: disa
     """
     arrs, attribute, event = [infer_array(data, condition) for data, condition in zip([arrs,    attribute,       event],
                                                                                 [is_2d_array, is_1d_array, is_1d_array])]
-    names = to_list(names)
+    names = to_list(names, arrs.size)
 
     # Implicitely rearange event array so it follows the logic.
     # In case multiple types of events and gathers passed, e.g. event =  (picking1 and picking2) and arrs = (raw, lift) 

--- a/seismicpro/src/plot_utils.py
+++ b/seismicpro/src/plot_utils.py
@@ -6,13 +6,16 @@ from matplotlib import patches
 from .utils import measure_gain_amplitude
 
 
+def imshow_set_defaults(ax, arr, **kwargs):
+    """ Calls ax.imshow(arr) with some set of arguments being fixed """
 
-def imshow_with_defaults(ax, arr, **kwargs):
-    """ """
-    kwargs.setdefault('cmap', 'gray')
-    kwargs.setdefault('vmax', np.quantile(arr, 0.9))
-    kwargs.setdefault('vmin', np.quantile(arr, 0.1))
-    ax.imshow(arr, **kwargs)
+    seismic_defaults = {
+        'cmap': 'gray',
+        'vmin': np.np.quantile(arr, 0.1),
+        'max': np.np.quantile(arr, 0.9),
+    }
+    ax.imshow(arr, aspect='auto', **{**seismic_defaults, **kwargs})
+
 
 def seismic_plot(arrs, wiggle=False, xlim=None, ylim=None, std=1, # pylint: disable=too-many-branches, too-many-arguments
                  pts=None, s=None, scatter_color=None, names=None, figsize=None,
@@ -98,7 +101,7 @@ def seismic_plot(arrs, wiggle=False, xlim=None, ylim=None, std=1, # pylint: disa
                     ax[0, i].fill_betweenx(y, k, x, where=(x > k), color=col)
 
             else:
-                imshow_with_defaults(ax[0, i], arr.T, **kwargs)
+                imshow_set_defaults(ax[0, i], arr.T, **kwargs)
 
         elif arr.ndim == 1:
             ax[0, i].plot(arr, **kwargs)
@@ -118,8 +121,6 @@ def seismic_plot(arrs, wiggle=False, xlim=None, ylim=None, std=1, # pylint: disa
 
         if pts is not None:
             ax[0, i].scatter(*pts, s=s, c=scatter_color)
-
-        ax[0, i].set_aspect('auto')
 
     if title is not None:
         fig.suptitle(title)
@@ -164,7 +165,7 @@ def spectrum_plot(arrs, frame, rate, max_freq=None, names=None,
 
     _, ax = plt.subplots(2, len(arrs), figsize=figsize, squeeze=False)
     for i, arr in enumerate(arrs):
-        imshow_with_defaults(ax[0, i], arr.T, **kwargs)
+        imshow_set_defaults(ax[0, i], arr.T, **kwargs)
         rect = patches.Rectangle((frame[0].start, frame[1].start),
                                  frame[0].stop - frame[0].start,
                                  frame[1].stop - frame[1].start,
@@ -181,9 +182,7 @@ def spectrum_plot(arrs, frame, rate, max_freq=None, names=None,
         mask = freqs <= max_freq
         ax[1, i].plot(freqs[mask], np.mean(spec, axis=0)[mask], lw=2)
         ax[1, i].set_xlabel('Hz')
-        ax[1, i].set_title('Spectrum plot {}'.format(names[i] if names
-                                                     is not None else ''))
-        ax[1, i].set_aspect('auto')
+        ax[1, i].set_title('Spectrum plot {}'.format(names[i] if names is not None else ''))
 
     if save_to is not None:
         plt.savefig(save_to, dpi=dpi)
@@ -260,6 +259,7 @@ def gain_plot(arrs, window=51, xlim=None, ylim=None, figsize=None,
 
     if save_to is not None:
         plt.savefig(save_to, dpi=dpi)
+
     plt.show()
 
 def statistics_plot(arrs, stats, rate=None, figsize=None, names=None,
@@ -322,8 +322,7 @@ def statistics_plot(arrs, stats, rate=None, figsize=None, names=None,
         ax[0, i].set_xlim([0, len(arr)])
         ax[0, i].set_aspect('auto')
         ax[0, i].set_title(names[i] if names is not None else '')
-        imshow_with_defaults(ax[1, i], arr.T, **kwargs)
-        ax[1, i].set_aspect('auto')
+        imshow_set_defaults(ax[1, i], arr.T, **kwargs)
 
     if save_to is not None:
         plt.savefig(save_to, dpi=dpi)

--- a/seismicpro/src/plot_utils.py
+++ b/seismicpro/src/plot_utils.py
@@ -6,6 +6,14 @@ from matplotlib import patches
 from .utils import measure_gain_amplitude
 
 
+
+def imshow_with_defaults(ax, arr, **kwargs):
+    """ """
+    kwargs.setdefault('cmap', 'gray')
+    kwargs.setdefault('vmax', np.quantile(arr, 0.9))
+    kwargs.setdefault('vmin', np.quantile(arr, 0.1))
+    ax.imshow(arr, **kwargs)
+
 def seismic_plot(arrs, wiggle=False, xlim=None, ylim=None, std=1, # pylint: disable=too-many-branches, too-many-arguments
                  pts=None, s=None, scatter_color=None, names=None, figsize=None,
                  save_to=None, dpi=None, line_color=None, title=None, **kwargs):
@@ -90,7 +98,7 @@ def seismic_plot(arrs, wiggle=False, xlim=None, ylim=None, std=1, # pylint: disa
                     ax[0, i].fill_betweenx(y, k, x, where=(x > k), color=col)
 
             else:
-                ax[0, i].imshow(arr.T, **kwargs)
+                imshow_with_defaults(ax[0, i], arr.T, **kwargs)
 
         elif arr.ndim == 1:
             ax[0, i].plot(arr, **kwargs)
@@ -115,13 +123,14 @@ def seismic_plot(arrs, wiggle=False, xlim=None, ylim=None, std=1, # pylint: disa
 
     if title is not None:
         fig.suptitle(title)
+
     if save_to is not None:
-        plt.savefig(save_to, dpi=dpi, transparent=True)
+        plt.savefig(save_to, dpi=dpi)
 
     plt.show()
 
 def spectrum_plot(arrs, frame, rate, max_freq=None, names=None,
-                  figsize=None, save_to=None, **kwargs):
+                  figsize=None, save_to=None, dpi=None, **kwargs):
     """Plot seismogram(s) and power spectrum of given region in the seismogram(s).
 
     Parameters
@@ -155,7 +164,7 @@ def spectrum_plot(arrs, frame, rate, max_freq=None, names=None,
 
     _, ax = plt.subplots(2, len(arrs), figsize=figsize, squeeze=False)
     for i, arr in enumerate(arrs):
-        ax[0, i].imshow(arr.T, **kwargs)
+        imshow_with_defaults(ax[0, i], arr.T, **kwargs)
         rect = patches.Rectangle((frame[0].start, frame[1].start),
                                  frame[0].stop - frame[0].start,
                                  frame[1].stop - frame[1].start,
@@ -177,11 +186,12 @@ def spectrum_plot(arrs, frame, rate, max_freq=None, names=None,
         ax[1, i].set_aspect('auto')
 
     if save_to is not None:
-        plt.savefig(save_to)
+        plt.savefig(save_to, dpi=dpi)
 
     plt.show()
 
-def gain_plot(arrs, window=51, xlim=None, ylim=None, figsize=None, names=None, **kwargs):# pylint: disable=too-many-branches
+def gain_plot(arrs, window=51, xlim=None, ylim=None, figsize=None, 
+              names=None, dpi=None, save_to=None, **kwargs):# pylint: disable=too-many-branches
     r"""Gain's graph plots the ratio of the maximum mean value of
     the amplitude to the mean value of the smoothed amplitude at the moment t.
 
@@ -247,10 +257,13 @@ def gain_plot(arrs, window=51, xlim=None, ylim=None, figsize=None, names=None, *
         ax[ix].set_xlim(set_xlim)
         ax[ix].set_xlabel('Maxamp/Amp')
         ax[ix].set_ylabel('Time')
+
+    if save_to is not None:
+        plt.savefig(save_to, dpi=dpi)
     plt.show()
 
 def statistics_plot(arrs, stats, rate=None, figsize=None, names=None,
-                    save_to=None, **kwargs):
+                    save_to=None, dpi=None, **kwargs):
     """Show seismograms and various trace statistics, e.g. rms amplitude and rms frequency.
 
     Parameters
@@ -309,11 +322,11 @@ def statistics_plot(arrs, stats, rate=None, figsize=None, names=None,
         ax[0, i].set_xlim([0, len(arr)])
         ax[0, i].set_aspect('auto')
         ax[0, i].set_title(names[i] if names is not None else '')
-        ax[1, i].imshow(arr.T, **kwargs)
+        imshow_with_defaults(ax[1, i], arr.T, **kwargs)
         ax[1, i].set_aspect('auto')
 
     if save_to is not None:
-        plt.savefig(save_to)
+        plt.savefig(save_to, dpi=dpi)
 
     plt.show()
 

--- a/seismicpro/src/plot_utils.py
+++ b/seismicpro/src/plot_utils.py
@@ -11,8 +11,9 @@ def imshow_set_defaults(ax, arr, **kwargs):
 
     seismic_defaults = {
         'cmap': 'gray',
-        'vmin': np.np.quantile(arr, 0.1),
-        'max': np.np.quantile(arr, 0.9),
+        'vmin': np.quantile(arr, 0.1),
+        'vmax': np.quantile(arr, 0.9),
+        'extent': (0, arr.shape[1], arr.shape[0], 0)
     }
     ax.imshow(arr, aspect='auto', **{**seismic_defaults, **kwargs})
 

--- a/seismicpro/src/seismic_batch.py
+++ b/seismicpro/src/seismic_batch.py
@@ -14,7 +14,7 @@ from ..batchflow import action, inbatch_parallel, Batch, any_action_failed
 
 from .seismic_index import SegyFilesIndex, FieldIndex, KNNIndex, TraceIndex, CustomIndex
 
-from .utils import (FILE_DEPENDEND_COLUMNS, partialmethod, calculate_sdc_for_field, massive_block)
+from .utils import (FILE_DEPENDEND_COLUMNS, partialmethod, calculate_sdc_for_field, massive_block, infer_axis_tickers)
 from .file_utils import write_segy_file
 from .plot_utils import spectrum_plot, seismic_plot, statistics_plot, gain_plot
 
@@ -1502,8 +1502,9 @@ class SeismicBatch(Batch):
     #-------------------------------------------------------------------------#
 
     def seismic_plot(self, src, index, wiggle=False, xlim=None, ylim=None, std=1, # pylint: disable=too-many-arguments
-                     src_picking=None, s=None, scatter_color=None, figsize=(10, 7),
-                     line_color=None, title=None, save_to=None, dpi=None, **kwargs):
+                     src_picking=None, s=None, scatter_color=None, figsize=(10, 7), 
+                     y_ticker='time', x_ticker=None, line_color=None, 
+                     title=None, save_to=None, dpi=None, **kwargs):
         """Plot seismic traces.
 
         Parameters
@@ -1556,11 +1557,15 @@ class SeismicBatch(Batch):
 
         arrs = [getattr(self, isrc)[pos] for isrc in src]
         names = [' '.join([i, str(index)]) for i in src]
+
+        x_ticker, y_ticker = infer_axis_tickers(self, index, src[0], x_ticker, y_ticker)
         seismic_plot(arrs=arrs, wiggle=wiggle, xlim=xlim, ylim=ylim, std=std,
                      pts=pts_picking, s=s, scatter_color=scatter_color,
                      figsize=figsize, names=names, save_to=save_to,
-                     dpi=dpi, line_color=line_color, title=title, **kwargs)
+                     dpi=dpi, line_color=line_color, title=title, 
+                     x_ticker=x_ticker, y_ticker=y_ticker, **kwargs)
         return self
+    
 
     def crops_plot(self, src, index, # pylint: disable=too-many-arguments
                    num_crops=None,

--- a/seismicpro/src/seismic_batch.py
+++ b/seismicpro/src/seismic_batch.py
@@ -1500,9 +1500,9 @@ class SeismicBatch(Batch):
     #-------------------------------------------------------------------------#
     #                                 Plotters                                #
     #-------------------------------------------------------------------------#
-    def seismic_plot(self, src, index=0, wiggle=False, xlim=None, ylim=None, std=1, # pylint: disable=too-many-arguments
+    def seismic_plot(self, src, pos=0, wiggle=False, xlim=None, ylim=None, std=1, # pylint: disable=too-many-arguments
                      src_picking=None, s=None, scatter_color=None,
-                     figsize=(10, 7), y_ticker='time', x_ticker=None,
+                     figsize=(10, 7), y_ticker='samples', x_ticker=None,
                      line_color=None, title=None, save_to=None, dpi=None, **kwargs):
         """Plot seismic traces.
 
@@ -1510,8 +1510,8 @@ class SeismicBatch(Batch):
         ----------
         src : str or array of str
             The batch component(s) with data to show.
-        index : same type as batch.indices
-            Data index to show.
+        pos : int, default 0
+            Position of the object in the batch to show.
         wiggle : bool, default to False
             Show traces in a wiggle form.
         xlim : tuple, optionalgit
@@ -1543,7 +1543,6 @@ class SeismicBatch(Batch):
         -------
         Multi-column subplots.
         """
-        pos = index
         if len(np.atleast_1d(src)) == 1:
             src = (src,)
 
@@ -1555,7 +1554,7 @@ class SeismicBatch(Batch):
             pts_picking = None
 
         arrs = [getattr(self, isrc)[pos] for isrc in src]
-        names = [' '.join([i, str(index)]) for i in src]
+        names = [' '.join([i, str(self.indices[pos])]) for i in src]
 
         x_ticker, y_ticker = infer_axis_tickers(self, self.indices[pos], src[0], x_ticker, y_ticker)
         seismic_plot(arrs=arrs, wiggle=wiggle, xlim=xlim, ylim=ylim, std=std,

--- a/seismicpro/src/seismic_batch.py
+++ b/seismicpro/src/seismic_batch.py
@@ -1503,7 +1503,7 @@ class SeismicBatch(Batch):
 
     def seismic_plot(self, src, index, wiggle=False, xlim=None, ylim=None, std=1, # pylint: disable=too-many-arguments
                      src_picking=None, s=None, scatter_color=None, figsize=(10, 7),
-                     save_to=None, dpi=None, line_color=None, title=None, **kwargs):
+                     line_color=None, title=None, save_to=None, dpi=None, **kwargs):
         """Plot seismic traces.
 
         Parameters
@@ -1635,7 +1635,7 @@ class SeismicBatch(Batch):
         return self
 
     def gain_plot(self, src, index, window=51, xlim=None, ylim=None,
-                  figsize=(10, 7), names=None,  save_to=None, dpi=300, **kwargs):
+                  figsize=(10, 7), names=None,  save_to=None, dpi=None, **kwargs):
         """Gain's graph plots the ratio of the maximum mean value of
         the amplitude to the mean value of the amplitude at the moment t.
 
@@ -1664,7 +1664,7 @@ class SeismicBatch(Batch):
         return self
 
     def spectrum_plot(self, src, index, frame, max_freq=None,
-                      figsize=(10, 10), save_to=None, dpi=300, **kwargs):
+                      figsize=(10, 10), save_to=None, dpi=None, **kwargs):
         """Plot seismogram(s) and power spectrum of given region in the seismogram(s).
 
         Parameters
@@ -1696,11 +1696,11 @@ class SeismicBatch(Batch):
         names = [' '.join([i, str(index)]) for i in src]
         rate = self.meta[src[0]]['interval'] / 1e6
         spectrum_plot(arrs=arrs, frame=frame, rate=rate, max_freq=max_freq,
-                      names=names, figsize=figsize, save_to=save_to, **kwargs)
+                      names=names, figsize=figsize, save_to=save_to, dpi=dpi, **kwargs)
         return self
 
     def statistics_plot(self, src, index, stats, figsize=(10, 10), 
-                        save_to=None, dpi=300, **kwargs):
+                        save_to=None, dpi=None, **kwargs):
         """Plot seismogram(s) and various trace statistics.
 
         Parameters
@@ -1730,5 +1730,5 @@ class SeismicBatch(Batch):
         names = [' '.join([i, str(index)]) for i in src]
         rate = self.meta[src[0]]['interval'] / 1e6
         statistics_plot(arrs=arrs, stats=stats, rate=rate, names=names, figsize=figsize,
-                        save_to=save_to, **kwargs)
+                        save_to=save_to, dpi=dpi, **kwargs)
         return self

--- a/seismicpro/src/seismic_batch.py
+++ b/seismicpro/src/seismic_batch.py
@@ -1500,7 +1500,7 @@ class SeismicBatch(Batch):
     #-------------------------------------------------------------------------#
     #                                 Plotters                                #
     #-------------------------------------------------------------------------#
-    def seismic_plot(self, src, index, wiggle=False, xlim=None, ylim=None, std=1, # pylint: disable=too-many-arguments
+    def seismic_plot(self, src, index=0, wiggle=False, xlim=None, ylim=None, std=1, # pylint: disable=too-many-arguments
                      src_picking=None, s=None, scatter_color=None,
                      figsize=(10, 7), y_ticker='time', x_ticker=None,
                      line_color=None, title=None, save_to=None, dpi=None, **kwargs):
@@ -1543,7 +1543,7 @@ class SeismicBatch(Batch):
         -------
         Multi-column subplots.
         """
-        pos = self.index.get_pos(index)
+        pos = index
         if len(np.atleast_1d(src)) == 1:
             src = (src,)
 
@@ -1557,7 +1557,7 @@ class SeismicBatch(Batch):
         arrs = [getattr(self, isrc)[pos] for isrc in src]
         names = [' '.join([i, str(index)]) for i in src]
 
-        x_ticker, y_ticker = infer_axis_tickers(self, index, src[0], x_ticker, y_ticker)
+        x_ticker, y_ticker = infer_axis_tickers(self, self.indices[pos], src[0], x_ticker, y_ticker)
         seismic_plot(arrs=arrs, wiggle=wiggle, xlim=xlim, ylim=ylim, std=std,
                      pts=pts_picking, s=s, scatter_color=scatter_color,
                      figsize=figsize, names=names, save_to=save_to,

--- a/seismicpro/src/seismic_batch.py
+++ b/seismicpro/src/seismic_batch.py
@@ -1500,11 +1500,10 @@ class SeismicBatch(Batch):
     #-------------------------------------------------------------------------#
     #                                 Plotters                                #
     #-------------------------------------------------------------------------#
-
     def seismic_plot(self, src, index, wiggle=False, xlim=None, ylim=None, std=1, # pylint: disable=too-many-arguments
-                     src_picking=None, s=None, scatter_color=None, figsize=(10, 7), 
-                     y_ticker='time', x_ticker=None, line_color=None, 
-                     title=None, save_to=None, dpi=None, **kwargs):
+                     src_picking=None, s=None, scatter_color=None,
+                     figsize=(10, 7), y_ticker='time', x_ticker=None,
+                     line_color=None, title=None, save_to=None, dpi=None, **kwargs):
         """Plot seismic traces.
 
         Parameters

--- a/seismicpro/src/seismic_batch.py
+++ b/seismicpro/src/seismic_batch.py
@@ -1511,7 +1511,7 @@ class SeismicBatch(Batch):
         ----------
         src : str or array of str
             The batch component(s) with data to show.
-        pos : int, default 0
+        pos : int of array-like, default 0
             Position of the object in the batch to show.
         wiggle : bool, default to False
             Show traces in a wiggle form.
@@ -1550,7 +1550,6 @@ class SeismicBatch(Batch):
             src = (src, )
         if isinstance(pos, int):
             pos = (pos, )
-        
 
         arrs = np.empty((len(pos), len(src)), 'O')
         for j, ipos in enumerate(pos):
@@ -1565,7 +1564,7 @@ class SeismicBatch(Batch):
             for j, ipos in enumerate(pos):
                 for i, isrc in enumerate(attribute_plot):
                     attribute[j, i] = getattr(self, isrc)[ipos]
-            attribute = np.broadcast_to(attribute, arrs.shape)
+            #attribute = np.broadcast_to(attribute, arrs.shape)
         else:
             attribute = None
 
@@ -1577,15 +1576,15 @@ class SeismicBatch(Batch):
             pts = np.empty((len(pos), len(src_picking)), 'O')
             for j, ipos in enumerate(pos):
                 for i, isrc in enumerate(src_picking):
-                    pts[j, i] = getattr(self, isrc)[ipos] / rate
+                    pts[j, i] = getattr(self, isrc)[ipos] #/ rate
     
-            if plot_single:
-                pts_copy = np.array(pts)
-                for i in range(pts.shape[0]):
-                    for j in range(pts.shape[1]):
-                        pts[i, j] = pts_copy[i, :]
+            # if plot_single:
+            #     pts_copy = np.array(pts)
+            #     for i in range(pts.shape[0]):
+            #         for j in range(pts.shape[1]):
+            #             pts[i, j] = pts_copy[i, :]
                 
-            pts = pts.flatten()
+            #pts = pts.flatten()
 
         else:
             pts = None
@@ -1674,13 +1673,15 @@ class SeismicBatch(Batch):
                      dpi=dpi, title=title, **kwargs)
         return self
 
-    def gain_plot(self, src, index, window=51, xlim=None, ylim=None,
+    def gain_plot(self, src, pos=0, window=51, xlim=None, ylim=None,
                   figsize=(10, 7), names=None,  save_to=None, dpi=None, **kwargs):
         """Gain's graph plots the ratio of the maximum mean value of
         the amplitude to the mean value of the amplitude at the moment t.
 
         Parameters
         ----------
+        pos : int, default 0
+            Position of the object in the batch to show.
         window : int, default 51
             Size of smoothing window of the median filter.
         xlim : tuple or list with size 2
@@ -1696,14 +1697,13 @@ class SeismicBatch(Batch):
         -------
         Gain's plot.
         """
-        _ = kwargs
-        pos = self.index.get_pos(index)
-        src = (src, ) if isinstance(src, str) else src
-        sample = [getattr(self, source)[pos] for source in src]
-        gain_plot(sample, window, xlim, ylim, figsize, names, **kwargs)
+        if isinstance(src, str):
+            src = (src, )
+        arrs = [getattr(self, source)[pos] for source in src]
+        gain_plot(arrs, window, xlim, ylim, figsize, names, **kwargs)
         return self
 
-    def spectrum_plot(self, src, index, frame, max_freq=None,
+    def spectrum_plot(self, src, pos=0, frame=None, max_freq=None,
                       figsize=(10, 10), save_to=None, dpi=None, **kwargs):
         """Plot seismogram(s) and power spectrum of given region in the seismogram(s).
 
@@ -1711,8 +1711,8 @@ class SeismicBatch(Batch):
         ----------
         src : str or array of str
             The batch component(s) with data to show.
-        index : same type as batch.indices
-            Data index to show.
+        pos : int, default 0
+            Position of the object in the batch to show.
         frame : tuple
             List of slices that frame region of interest.
         max_freq : scalar
@@ -1728,18 +1728,16 @@ class SeismicBatch(Batch):
         -------
         Plot of seismogram(s) and power spectrum(s).
         """
-        pos = self.index.get_pos(index)
-        if len(np.atleast_1d(src)) == 1:
+        if isinstance(src, str):
             src = (src,)
-
         arrs = [getattr(self, isrc)[pos] for isrc in src]
-        names = [' '.join([i, str(index)]) for i in src]
+        names = [' '.join([i, str(self.indices[pos])]) for i in src]
         rate = self.meta[src[0]]['interval'] / 1e6
         spectrum_plot(arrs=arrs, frame=frame, rate=rate, max_freq=max_freq,
                       names=names, figsize=figsize, save_to=save_to, dpi=dpi, **kwargs)
         return self
 
-    def statistics_plot(self, src, index, stats, figsize=(10, 10), 
+    def statistics_plot(self, src, pos=0, stats=None, figsize=(10, 10), 
                         save_to=None, dpi=None, **kwargs):
         """Plot seismogram(s) and various trace statistics.
 
@@ -1762,12 +1760,11 @@ class SeismicBatch(Batch):
         -------
         Plot of seismogram(s) and power spectrum(s).
         """
-        pos = self.index.get_pos(index)
-        if len(np.atleast_1d(src)) == 1:
+        if isinstance(src, str):
             src = (src,)
 
         arrs = [getattr(self, isrc)[pos] for isrc in src]
-        names = [' '.join([i, str(index)]) for i in src]
+        names = [' '.join([i, str(self.indices[pos])]) for i in src]
         rate = self.meta[src[0]]['interval'] / 1e6
         statistics_plot(arrs=arrs, stats=stats, rate=rate, names=names, figsize=figsize,
                         save_to=save_to, dpi=dpi, **kwargs)

--- a/seismicpro/src/seismic_batch.py
+++ b/seismicpro/src/seismic_batch.py
@@ -15,9 +15,9 @@ from ..batchflow import action, inbatch_parallel, Batch, any_action_failed
 from .seismic_index import SegyFilesIndex, FieldIndex, KNNIndex, TraceIndex, CustomIndex
 
 from .utils import (FILE_DEPENDEND_COLUMNS, partialmethod, calculate_sdc_for_field, 
-                    massive_block, infer_axis_tickers, to_list, collect_components_data )
+                    massive_block, to_list, collect_components_data )
 from .file_utils import write_segy_file
-from .plot_utils import spectrum_plot, seismic_plot, statistics_plot, gain_plot
+from .plot_utils import spectrum_plot, seismic_plot, statistics_plot, gain_plot, infer_axis_tickers
 
 INDEX_UID = 'TRACE_SEQUENCE_FILE'
 

--- a/seismicpro/src/seismic_batch.py
+++ b/seismicpro/src/seismic_batch.py
@@ -1505,7 +1505,7 @@ class SeismicBatch(Batch):
     def seismic_plot(self, src, pos=0, # pylint: disable=too-many-arguments
                      xlim=None, ylim=None, wiggle=False, std=1,
                      src_event=None, s=None, c=None, src_attribute=None,
-                     figsize=(9, 6), title=None, line_color='k',
+                     figsize=(9, 6), title=None, line_color='k', names=None,
                      y_ticker='samples', x_ticker=None,
                      save_to=None, dpi=None, **kwargs):
         """Plot seismic traces.
@@ -1559,7 +1559,7 @@ class SeismicBatch(Batch):
 
         seismic_plot(arrs=arrs, xlim=xlim, ylim=ylim, wiggle=wiggle, std=std, 
                      event=event, s=s, c=c, attribute=attribute, 
-                     figsize=figsize, columnwise=False, line_color=line_color, title=title, names=names, 
+                     figsize=figsize, line_color=line_color, title=title, names=names, 
                      x_ticker=x_ticker, y_ticker=y_ticker, 
                      save_to=save_to, dpi=dpi, **kwargs)
         return self
@@ -1633,7 +1633,7 @@ class SeismicBatch(Batch):
 
         seismic_plot(arrs=arrs, wiggle=wiggle, std=std,
                      pts=pts_picking, s=s, scatter_color=scatter_color,
-                     figsize=figsize, names=names, save_to=save_to,
+                     figsize=figsize, columnwise=False, names=names, save_to=save_to,
                      dpi=dpi, title=title, **kwargs)
         return self
 
@@ -1664,6 +1664,7 @@ class SeismicBatch(Batch):
         src = to_list(src)
         arrs = [getattr(self, isrc)[pos] for isrc in src]
         names = names or [' '.join([i, str(self.indices[pos])]) for i in src]
+
         gain_plot(arrs, window, xlim, ylim, figsize, names, **kwargs)
         return self
 
@@ -1693,9 +1694,10 @@ class SeismicBatch(Batch):
         Plot of seismogram(s) and power spectrum(s).
         """
         src = to_list(src)
-        arrs = [getattr(self, isrc)[pos] for isrc in src]
+        arrs = collect_components_data(self, src, pos)
         names = [' '.join([i, str(self.indices[pos])]) for i in src]
         rate = self.meta[src[0]]['interval'] / 1e6
+
         spectrum_plot(arrs=arrs, frame=frame, rate=rate, max_freq=max_freq,
                       names=names, figsize=figsize, save_to=save_to, dpi=dpi, **kwargs)
         return self
@@ -1725,9 +1727,10 @@ class SeismicBatch(Batch):
         Plot of seismogram(s) and power spectrum(s).
         """
         src = to_list(src)
-        arrs = [getattr(self, isrc)[pos] for isrc in src]
+        arrs = collect_components_data(self, src, pos)
         names = [' '.join([isrc, str(self.indices[pos])]) for isrc in src]
         rate = self.meta[src[0]]['interval'] / 1e6
+    
         statistics_plot(arrs=arrs, stats=stats, rate=rate, names=names, figsize=figsize,
                         save_to=save_to, dpi=dpi, **kwargs)
         return self

--- a/seismicpro/src/seismic_batch.py
+++ b/seismicpro/src/seismic_batch.py
@@ -1502,7 +1502,7 @@ class SeismicBatch(Batch):
     #-------------------------------------------------------------------------#
 
     def seismic_plot(self, src, index, wiggle=False, xlim=None, ylim=None, std=1, # pylint: disable=too-many-arguments
-                     src_picking=None, s=None, scatter_color=None, figsize=None,
+                     src_picking=None, s=None, scatter_color=None, figsize=(10, 7),
                      save_to=None, dpi=None, line_color=None, title=None, **kwargs):
         """Plot seismic traces.
 
@@ -1635,7 +1635,7 @@ class SeismicBatch(Batch):
         return self
 
     def gain_plot(self, src, index, window=51, xlim=None, ylim=None,
-                  figsize=None, names=None, **kwargs):
+                  figsize=(10, 7), names=None,  save_to=None, dpi=300, **kwargs):
         """Gain's graph plots the ratio of the maximum mean value of
         the amplitude to the mean value of the amplitude at the moment t.
 
@@ -1664,7 +1664,7 @@ class SeismicBatch(Batch):
         return self
 
     def spectrum_plot(self, src, index, frame, max_freq=None,
-                      figsize=None, save_to=None, **kwargs):
+                      figsize=(10, 10), save_to=None, dpi=300, **kwargs):
         """Plot seismogram(s) and power spectrum of given region in the seismogram(s).
 
         Parameters
@@ -1699,7 +1699,8 @@ class SeismicBatch(Batch):
                       names=names, figsize=figsize, save_to=save_to, **kwargs)
         return self
 
-    def statistics_plot(self, src, index, stats, figsize=None, save_to=None, **kwargs):
+    def statistics_plot(self, src, index, stats, figsize=(10, 10), 
+                        save_to=None, dpi=300, **kwargs):
         """Plot seismogram(s) and various trace statistics.
 
         Parameters

--- a/seismicpro/src/utils.py
+++ b/seismicpro/src/utils.py
@@ -810,7 +810,6 @@ def infer_axis_tickers(batch, index, src, x_tick, y_tick):
         else:
             xticks_labels = df[x_tick]
         x_ticker['formatter'] = IndexFormatter(xticks_labels)
-
     elif isinstance(x_tick, dict): # dict with config passed, it will be used directly
         x_ticker = x_tick
     elif isinstance(x_tick, (list, tuple, np.ndarray)): # ticker will be inferred later in utils.setup_tickers
@@ -820,14 +819,27 @@ def infer_axis_tickers(batch, index, src, x_tick, y_tick):
     if y_tick == 'time': # infer ticker from meta
         yticks_labels = batch.meta[src]['samples']
         y_ticker['formatter'] = IndexFormatter(yticks_labels)
-
-    elif y_ticker == 'samples': # default ticker will be used
+    elif y_tick == 'samples': # default ticker will be used
         pass 
-
     elif isinstance(y_tick, dict): 
         y_ticker = y_tick
-    
     elif isinstance(x_tick, (list, tuple, np.ndarray)): # ticker will be inferred later in utils.setup_tickers
-        y_ticker = x_tick
+        y_ticker = y_tick
     
     return x_ticker, y_ticker
+
+def collect_components_data(batch, src, pos):
+    if src[0] is None:
+        return None        
+    data = np.empty((len(pos), len(src)), 'O')
+    for j, ipos in enumerate(pos):
+        for i, isrc in enumerate(src):
+            data[j, i] = getattr(batch, isrc)[ipos]
+    return data
+
+def to_list(obj):
+    """Cast an object to a list. Almost identical to `list(obj)` for 1-D
+    objects, except for `str`, which won't be split into separate letters but
+    transformed into a list of a single element.
+    """
+    return np.ravel(obj).tolist()

--- a/seismicpro/src/utils.py
+++ b/seismicpro/src/utils.py
@@ -794,32 +794,40 @@ def transform_to_fixed_width_columns(path, path_save=None, n_spaces=8, max_len=(
                 return
             shutil.copyfile(write_file.name, path)
 
-def infer_axis_tickers(batch, index, src, x_ticker, y_ticker):
+def infer_axis_tickers(batch, index, src, x_tick, y_tick):
     """ In case x_ticker / y_ticker strings, corresponding tickers will be infered from dataframe / meta. 
     In case x_ticker / y_ticker dicts, they should contains axis configuration and will be used as is. 
     """    
     df = batch.index.get_df(index)
 
-    ticker_x, ticker_y = {}, {}
+    x_ticker, y_ticker = {}, {}
     
-    # process x-axis
-    if isinstance(x_ticker, str): # infer tickers from dataframe
+    # process x-ticker
+    if isinstance(x_tick, str): # infer ticker from dataframe
         sorting = batch.meta[src]['sorting']
         if sorting is not None:
-            xticks_labels = df.sort_values(sorting)[x_ticker]
+            xticks_labels = df.sort_values(sorting)[x_tick]
         else:
-            xticks_labels = df[x_ticker]
-        ticker_x['x_formatter'] = IndexFormatter(xticks_labels)
-    elif isinstance(x_ticker, dict): # dict with config passed, it will be used directly
-        ticker_x = x_ticker
+            xticks_labels = df[x_tick]
+        x_ticker['formatter'] = IndexFormatter(xticks_labels)
 
-    # process y-axis
-    if y_ticker == 'time': # infer tickers from meta
+    elif isinstance(x_tick, dict): # dict with config passed, it will be used directly
+        x_ticker = x_tick
+    elif isinstance(x_tick, (list, tuple, np.ndarray)): # ticker will be inferred later in utils.setup_tickers
+        x_ticker = x_tick
+
+    # process y-ticker
+    if y_tick == 'time': # infer ticker from meta
         yticks_labels = batch.meta[src]['samples']
-        ticker_y['y_formatter'] = IndexFormatter(yticks_labels)
-    elif y_ticker == 'samples': # default tickers will be used
-        pass
-    elif isinstance(y_ticker, dict): # dict with config passed, it will be used directly
-        ticker_y = y_ticker
+        y_ticker['formatter'] = IndexFormatter(yticks_labels)
+
+    elif y_ticker == 'samples': # default ticker will be used
+        pass 
+
+    elif isinstance(y_tick, dict): 
+        y_ticker = y_tick
     
-    return ticker_x, ticker_y
+    elif isinstance(x_tick, (list, tuple, np.ndarray)): # ticker will be inferred later in utils.setup_tickers
+        y_ticker = x_tick
+    
+    return x_ticker, y_ticker

--- a/seismicpro/src/utils.py
+++ b/seismicpro/src/utils.py
@@ -805,11 +805,11 @@ def collect_components_data(batch, src, pos):
             data[i, j] = getattr(batch, isrc)[ipos]
     return data
 
-def is_2d_array(array):
-    return np.isscalar(array[0][0])
-
 def is_1d_array(array):
     return np.isscalar(array[0])
+
+def is_2d_array(array):
+    return not is_1d_array(array) and np.isscalar(array[0][0])
 
 def infer_array(data, cond):
     """ Given the nested(max depth 2) structure of objects,  where the object is defined 
@@ -835,9 +835,9 @@ def infer_array(data, cond):
     return blank
 
 def to_list(obj, n=1):
-    """Cast an object to a list and repeat it n times. Almost identical to `list(obj)` for 1-D
+    """Cast an object to a list. Almost identical to `list(obj)` for 1-D
     objects, except for `str`, which won't be split into separate letters but
-    transformed into a list of a single element.
+    transformed into a list of a single element. Optionally list may be repeated n times.
     """
     return np.ravel(obj).tolist() * n
      

--- a/seismicpro/src/utils.py
+++ b/seismicpro/src/utils.py
@@ -794,52 +794,50 @@ def transform_to_fixed_width_columns(path, path_save=None, n_spaces=8, max_len=(
                 return
             shutil.copyfile(write_file.name, path)
 
-def infer_axis_tickers(batch, index, src, x_tick, y_tick):
-    """ In case x_ticker / y_ticker strings, corresponding tickers will be infered from dataframe / meta. 
-    In case x_ticker / y_ticker dicts, they should contains axis configuration and will be used as is. 
-    """    
-    df = batch.index.get_df(index)
-
-    x_ticker, y_ticker = {}, {}
-    
-    # process x-ticker
-    if isinstance(x_tick, str): # infer ticker from dataframe
-        sorting = batch.meta[src]['sorting']
-        if sorting is not None:
-            xticks_labels = df.sort_values(sorting)[x_tick]
-        else:
-            xticks_labels = df[x_tick]
-        x_ticker['formatter'] = IndexFormatter(xticks_labels)
-    elif isinstance(x_tick, dict): # dict with config passed, it will be used directly
-        x_ticker = x_tick
-    elif isinstance(x_tick, (list, tuple, np.ndarray)): # ticker will be inferred later in utils.setup_tickers
-        x_ticker = x_tick
-
-    # process y-ticker
-    if y_tick == 'time': # infer ticker from meta
-        yticks_labels = batch.meta[src]['samples']
-        y_ticker['formatter'] = IndexFormatter(yticks_labels)
-    elif y_tick == 'samples': # default ticker will be used
-        pass 
-    elif isinstance(y_tick, dict): 
-        y_ticker = y_tick
-    elif isinstance(x_tick, (list, tuple, np.ndarray)): # ticker will be inferred later in utils.setup_tickers
-        y_ticker = y_tick
-    
-    return x_ticker, y_ticker
-
 def collect_components_data(batch, src, pos):
+    """ Collect data from the batch. 
+    Packs it into 2d array 'O' dtype, where each elent is a component object. """
     if src[0] is None:
         return None        
     data = np.empty((len(pos), len(src)), 'O')
-    for j, ipos in enumerate(pos):
-        for i, isrc in enumerate(src):
-            data[j, i] = getattr(batch, isrc)[ipos]
+    for i, ipos in enumerate(pos):
+        for j, isrc in enumerate(src):
+            data[i, j] = getattr(batch, isrc)[ipos]
     return data
 
-def to_list(obj):
-    """Cast an object to a list. Almost identical to `list(obj)` for 1-D
+def is_2d_array(array):
+    return np.isscalar(array[0][0])
+
+def is_1d_array(array):
+    return np.isscalar(array[0])
+
+def infer_array(data, cond):
+    """ Given the nested(max depth 2) structure of objects,  where the object is defined 
+    by the condition (for example: for gather - is_2d_array, for horizon - is_1d_array) rearange it into
+    np.2darray with 'O' dtype. Each element of resulted array is a requsted object.
+    """
+    if data is None:
+        return None 
+
+    if cond(data): # data is a desired object, wrap it into 'O' array with shape 1x1 
+        blank = np.empty((1, 1), 'O')
+        blank[0, 0] = data
+    elif cond(data[0]): # data is a iterable of objects, wrap it into array with the shape 1xN
+        blank = np.empty((1, len(data)),  'O')
+        for i, _ in enumerate(data):
+            blank[0, i] = data[i]
+    elif cond(data[0][0]):  # data is a nested(depth 2) structure of objects, wrap it into array with the shape MxN
+        blank = np.empty((len(data), len(data[0])), 'O')
+        for i, _ in enumerate(data):
+            for j, _ in enumerate(data[0]):
+                blank[i, j] = data[i][j]
+
+    return blank
+
+def to_list(obj, n=1):
+    """Cast an object to a list and repeat it n times. Almost identical to `list(obj)` for 1-D
     objects, except for `str`, which won't be split into separate letters but
     transformed into a list of a single element.
     """
-    return np.ravel(obj).tolist()
+    return np.ravel(obj).tolist() * n
+     


### PR DESCRIPTION
- [x] predefine arguments (`cmap, vmax, vmin, aspect`) for plotters 
- [x] plotters `index` argument replaced by `pos` 
now it is the position of the gather in the batch, i.e. 0, 1, ..., len(batch), not the fair index(FFID). `pos=0` by default 
- [x] unify saving(a bit)
- [x] rm blank lines on the boarders of the plots
- [x]  label axis ( for y axis time/sample units, for x based on some trace attribute. or based on [tickers](https://matplotlib.org/api/ticker_api.html#matplotlib.ticker.FixedFormatter))
- [x] additional small attribute plot  on top of the gather plot
- [x] plot multiple gathers via single plot call

-----

![image](https://user-images.githubusercontent.com/8656643/101404750-20df3800-38e8-11eb-92d6-8bf35fd2dca5.png)

----

![image](https://user-images.githubusercontent.com/8656643/101412745-2c386080-38f4-11eb-969f-81a3318c8737.png)

---
Specify axis ticks labels via `x_ticker` and  `y_ticker`: x -offset, y - time
![image](https://user-images.githubusercontent.com/8656643/101405326-f9d53600-38e8-11eb-9095-fc9024bcba1c.png)

---

More flexible way to adjust axis - specify **where** and **what** would be displayed via _Locator_ and _Formatter_ 
![image](https://user-images.githubusercontent.com/8656643/101409376-e200b080-38ee-11eb-8f98-a4a2b12fb5a4.png)

---

On top of the seismogramm plot how some attribute vary from trace to trace via `src_attribute`
Plot the horizons or any events on the seismogram itself via `src_event`
![image](https://user-images.githubusercontent.com/8656643/106140100-5cc3aa80-617f-11eb-92b9-59d9ee77d58b.png)

---

There can be multiple events passed.
![image](https://user-images.githubusercontent.com/8656643/106140741-36ead580-6180-11eb-9c70-b4bf731382b8.png)

---

**Note**: in case multiple events and multiple sources of seismogramms passed, the events are splitter among seismograms.

![image](https://user-images.githubusercontent.com/8656643/106142857-107a6980-6183-11eb-9fd0-95dfa7f90f26.png)







