### PR TITLE
reindex improvements

### DIFF
--- a/seismicpro/src/dataset.py
+++ b/seismicpro/src/dataset.py
@@ -109,7 +109,7 @@ class SeismicDataset(Dataset):
         return type(self).from_dataset(self, index)
 
     def reindex(self, new_index, reindex_nested=False, reindex_surveys=False):
-        """Reindex the index of `self` with new headers columns.
+        """Perform inplace reindexation of the index of `self` with new headers columns.
 
         Parameters
         ----------

--- a/seismicpro/src/dataset.py
+++ b/seismicpro/src/dataset.py
@@ -108,6 +108,27 @@ class SeismicDataset(Dataset):
             index = self.index.create_subset(index)
         return type(self).from_dataset(self, index)
 
+    def reindex(self, new_index, reindex_nested=False, reindex_surveys=False):
+        """Reindex the index of `self` with new headers columns.
+
+        Parameters
+        ----------
+        new_index : str or list of str
+            Headers columns to become a new index. Note, that `CONCAT_ID` is always preserved in the index and should
+            not be specified.
+        reindex_nested : bool, optional, defaults to False
+            Whether to reindex `train`, `test` and `validation` parts of the index.
+        reindex_surveys : bool, optional, defaults to False
+            Whether to reindex all underlying surveys.
+
+        Returns
+        -------
+        self : SeismicDataset
+            `self` reindexed inplace.
+        """
+        self.index.reindex(new_index, reindex_nested=reindex_nested, reindex_surveys=reindex_surveys, inplace=True)
+        return self
+
     def collect_stats(self, n_quantile_traces=100000, quantile_precision=2, stats_limits=None, bar=True):
         """Collect the following trace data statistics for each survey in the dataset:
         1. Min and max amplitude,

--- a/seismicpro/src/decorators.py
+++ b/seismicpro/src/decorators.py
@@ -10,7 +10,7 @@ from ..batchflow import action, inbatch_parallel
 def batch_method(*args, target="for", args_to_unpack=None, force=False, copy_src=True):
     """Mark a method as being added to `SeismicBatch` class.
 
-    The new method is added by :func:`~decorators.create_batch_methods` decorator of `SeismicBatch` if the parant class
+    The new method is added by :func:`~decorators.create_batch_methods` decorator of `SeismicBatch` if the parent class
     is listed in its arguments and parallelly redirects calls to elements of the batch. A method will be created only
     if there is no method with the same name in the batch class or if `force` flag was set to `True`.
 

--- a/seismicpro/src/utils/general_utils.py
+++ b/seismicpro/src/utils/general_utils.py
@@ -10,9 +10,9 @@ def to_list(obj):
     return np.array(obj).ravel().tolist()
 
 
-def maybe_copy(obj, inplace=False):
+def maybe_copy(obj, inplace=False, **kwargs):
     """Copy an object if `inplace` flag is set to `False`. Otherwise return the object unchanged."""
-    return obj if inplace else obj.copy()
+    return obj if inplace else obj.copy(**kwargs)
 
 
 def unique_indices_sorted(arr):


### PR DESCRIPTION
* Fix `SeismicIndex.reindex`:
    * Now iteration is allowed over reindexed instance,
    * Now it's possible to optionally reindex all nested indices (`train`, `test` and `validation`),
    * Reindexing of underlying surveys is now optional.
* Add reindex to `SeismicDataset` which simply reindexes its `index` attribute