### PR TITLE
fix split_model_outputs

### DIFF
--- a/seismicpro/src/batch.py
+++ b/seismicpro/src/batch.py
@@ -261,8 +261,7 @@ class SeismicBatch(Batch):
             A component's name with data to split.
         dst : str or NamedExpression
             - If `str`, save the resulting sub-arrays into a batch component called `dst`,
-            - If `NamedExpression`, save the resulting sub-arrays into the corresponding attribute for each element of
-              a component, defined by the named expression.
+            - If `NamedExpression`, save the resulting sub-arrays into the object described by named expression.
         shapes : 1d array-like
             An array with sizes of each sub-array along zero axis after the split. Its length should be generally equal
             to the current batch size and its sum must match the length of data defined by `src`.
@@ -289,5 +288,5 @@ class SeismicBatch(Batch):
         elif isinstance(dst, NamedExpression):
             dst.set(value=split_data)
         else:
-            raise ValueError(f'dst must be either `str` or `NamedExpression`, not {type(dst)}.')
+            raise ValueError(f"dst must be either `str` or `NamedExpression`, not {type(dst)}.")
         return self

--- a/seismicpro/src/batch.py
+++ b/seismicpro/src/batch.py
@@ -259,10 +259,10 @@ class SeismicBatch(Batch):
         ----------
         src : str
             A component's name with data to split.
-        dst : str or BA
+        dst : str or NamedExpression
             - If `str`, save the resulting sub-arrays into a batch component called `dst`,
-            - If `BA`, save the resulting sub-arrays into the corresponding attribute for each element of a component,
-              defined by the named expression.
+            - If `NamedExpression`, save the resulting sub-arrays into the corresponding attribute for each element of
+              a component, defined by the named expression.
         shapes : 1d array-like
             An array with sizes of each sub-array along zero axis after the split. Its length should be generally equal
             to the current batch size and its sum must match the length of data defined by `src`.
@@ -276,7 +276,7 @@ class SeismicBatch(Batch):
         ------
         ValueError
             If data length does not match the sum of shapes passed.
-            If `dst` is not of `str` or `BA` type.
+            If `dst` is not of `str` or `NamedExpression` type.
         """
         data = getattr(self, src)
         shapes = np.cumsum(shapes)
@@ -289,5 +289,5 @@ class SeismicBatch(Batch):
         elif isinstance(dst, NamedExpression):
             dst.set(value=split_data)
         else:
-            raise ValueError(f'dst must be either `str` or NamedExpression, not {type(dst)}.')
+            raise ValueError(f'dst must be either `str` or `NamedExpression`, not {type(dst)}.')
         return self

--- a/seismicpro/src/batch.py
+++ b/seismicpro/src/batch.py
@@ -6,7 +6,7 @@ from .gather import Gather
 from .semblance import Semblance, ResidualSemblance
 from .decorators import create_batch_methods, apply_to_each_component
 from .utils import to_list
-from ..batchflow import Batch, action, DatasetIndex, BA
+from ..batchflow import Batch, action, DatasetIndex, NamedExpression
 
 
 @create_batch_methods(Gather, Semblance, ResidualSemblance)
@@ -228,7 +228,7 @@ class SeismicBatch(Batch):
         setattr(self, dst, data)
         return self
 
-    @action
+    @action(no_eval='dst')
     def split_model_outputs(self, src, dst, shapes):
         """Split data into multiple sub-arrays whose shapes along zero axis if defined by `shapes`.
 
@@ -286,8 +286,8 @@ class SeismicBatch(Batch):
 
         if isinstance(dst, str):
             setattr(self, dst, split_data)
-        elif isinstance(dst, BA):
+        elif isinstance(dst, NamedExpression):
             dst.set(value=split_data)
         else:
-            ValueError(f'dst must be either `str` or `BA` named expression, not {type(dst)}.')
+            raise ValueError(f'dst must be either `str` or NamedExpression, not {type(dst)}.')
         return self


### PR DESCRIPTION
* Add no_eval mode for dst parameter in `split_model_outputs` function if NamedExpression is passed.
* Fix raise when given dst has wrong type