### PR TITLE
mark dead traces

### DIFF
--- a/seismicpro/src/survey.py
+++ b/seismicpro/src/survey.py
@@ -224,9 +224,9 @@ class Survey:  # pylint: disable=too-many-instance-attributes
 
         After the method is executed `has_stats` flag is set to `True` and all the calculated values can be obtained
         via corresponding attributes.
-        
-        The method also appends 'DeadTrace' column to `headers`. The value of this column is 1 if the corresponding trace 
-        is constant (dead), otherwise, the value is 0.
+
+        The method also appends 'DeadTrace' column to `headers`.
+        The value of this column is 1 if the corresponding trace is constant (dead), otherwise, the value is 0.
 
         Parameters
         ----------
@@ -287,7 +287,7 @@ class Survey:  # pylint: disable=too-many-instance-attributes
             # Sample random traces to calculate approximate quantiles
             if i < n_quantile_traces:
                 traces_buf[i] = trace
-                
+
         self.n_dead_traces = len(dead_indices)
         self.headers['DeadTrace'] = 0
         self.headers.loc[self.headers["TRACE_SEQUENCE_FILE"].isin(dead_indices), 'DeadTrace'] = 1
@@ -683,7 +683,7 @@ class Survey:  # pylint: disable=too-many-instance-attributes
         if limits[-1] < 0:
             raise ValueError('Negative step is not allowed.')
         return slice(*limits)
-    
+
     def remove_dead_traces(self, recollect_stats=False, inplace=False):
         """ Removes dead (constant) traces from survey's data.
         Recalculates surveys statistics if needed

--- a/seismicpro/src/tests/gather_test.py
+++ b/seismicpro/src/tests/gather_test.py
@@ -117,9 +117,9 @@ def test_gather_getitem_gathers(gather, key):
 
     # Check that the headers and samples contain  proper values
     ## This is probably not the best way for the equality check..
-    keys = tuple(to_list(k) if isinstance(k, tuple) else k for k in keys)
+    keys = tuple(to_list(k) if not isinstance(k, slice) else k for k in keys)
     keys = (keys[0], slice(None)) if len(keys) < 2 else keys
-    assert np.allclose(result_getitem.headers, gather.headers.iloc[keys[0]].values)
+    assert result_getitem.headers.equals(gather.headers.iloc[keys[0]])
     assert np.allclose(result_getitem.samples, gather.samples[keys[1]])
 
 


### PR DESCRIPTION
keeping dead trace indicator in headers allows convenient fitering