### PR TITLE
Add "hist" mode in `gather.plot`

### DIFF
--- a/seismicpro/src/batch.py
+++ b/seismicpro/src/batch.py
@@ -487,12 +487,12 @@ class SeismicBatch(Batch):
 
                 # Format subplot title
                 if title_template is not None:
-                    title = as_dict(title_template, key='label')
-                    label = title.pop("label")
+                    src_title = as_dict(title_template, key='label')
+                    label = src_title.pop("label")
                     format_names = {name for _, name, _, _ in Formatter().parse(label) if name is not None}
-                    format_kwargs = {name: title.pop(name) for name in format_names if name in title}
-                    title["label"] = label.format(src=src, index=index, **format_kwargs)
-                    kwargs["title"] = title
+                    format_kwargs = {name: src_title.pop(name) for name in format_names if name in src_title}
+                    src_title["label"] = label.format(src=src, index=index, **format_kwargs)
+                    kwargs["title"] = src_title
 
                 # Create subplotter config
                 subplot_config = {

--- a/seismicpro/src/decorators.py
+++ b/seismicpro/src/decorators.py
@@ -25,9 +25,7 @@ def plotter(figsize, args_to_unpack=None):
     """Expand the functionality of a plotting method by defining figure creation and saving.
 
     The decorated method is supposed to accept an `ax` argument. If it's not passed during the call, the decorator
-    creates it with the `figsize` provided. Before calling the decorated method, `kwargs` are processed as follows: all
-    text formatting arguments are popped from `kwargs` and set as defaults for 'title', 'x_ticker' and 'y_ticker'.
-
+    creates it with the `figsize` provided.
     A new argument is added for the decorated method:
     save_to : str or dict, optional, defaults to None
         If `str`, a path to save the figure to.

--- a/seismicpro/src/decorators.py
+++ b/seismicpro/src/decorators.py
@@ -6,7 +6,7 @@ from collections import defaultdict
 
 import matplotlib.pyplot as plt
 
-from .utils import to_list, save_figure, set_text_formatting, as_dict
+from .utils import to_list, save_figure, as_dict
 from ..batchflow import action, inbatch_parallel
 
 
@@ -57,7 +57,6 @@ def plotter(figsize, args_to_unpack=None):
     def decorator(method):
         @wraps(method)
         def plot(*args, **kwargs):
-            kwargs = set_text_formatting(kwargs)
             if "ax" in kwargs:
                 return method(*args, **kwargs)
             fig, ax = plt.subplots(1, 1, figsize=kwargs.pop("figsize", figsize))

--- a/seismicpro/src/gather.py
+++ b/seismicpro/src/gather.py
@@ -1042,8 +1042,7 @@ class Gather:
 
     @plotter(figsize=(10, 7))
     def plot(self, mode="seismogram", title=None, x_ticker=None, y_ticker=None, ax=None, **kwargs):
-        """ TODO
-        Plot gather traces.
+        """Plot gather traces.
 
         The traces can be displayed in a number of representations, depending on the `mode` provided. Currently, the
         following options are supported:

--- a/seismicpro/src/gather.py
+++ b/seismicpro/src/gather.py
@@ -1157,6 +1157,7 @@ class Gather:
             ax.set_yscale("log")
         return ax
 
+    # pylint: disable=too-many-arguments
     def _plot_seismogram(self, ax, colorbar=False, qvmin=0.1, qvmax=0.9, x_ticker=None, y_ticker=None,
                          x_tick_src=None, y_tick_src='time', event_headers=None, top_header=None, **kwargs):
         """Plot the gather as a 2d grayscale image of seismic traces."""

--- a/seismicpro/src/gather.py
+++ b/seismicpro/src/gather.py
@@ -1058,12 +1058,12 @@ class Gather:
             * `color`: defines a color for each trace. If a single color is given, it is applied to all the traces
               (defaults to black).
         - `hist`: a histogram of the trace data amplitudes or header values. The mode supports following `kwargs`:
-            * `bins`: number of equal-width bins if an integer; bin edges, including the left edge of the first bin and
-              the right edge of the last bin if a sequence.
+            * `bins`: if integer, number of equal-width bins; if sequence, bin edges that include the left edge of the
+              first bin and the right edge of the last bin.
             * `grid`: whether to show the grid lines.
             * `log`: set y-axis to log scale. If True, formatting defined in `y_ticker` is discarded.
 
-        Trace headers, whose values are measured in milliseconds (e.g. first break times) may be displayed over the
+        Trace headers, whose values are measured in milliseconds (e.g. first break times) may be displayed over a
         seismigram or wiggle plot if passed as `event_headers`. If `top_header` is passed, an auxiliary scatter plot of
         values of this header will be shown on top of the gather plot.
 
@@ -1078,8 +1078,8 @@ class Gather:
             * `step_labels`: place ticks with a given step between two adjacent ones in the units of the corresponding
               labels (e.g. place a tick every 200ms for `y` axis or every 300m offset for `x` axis). This option is
               valid only for "seismogram" and "wiggle" modes.
-        A short argument form allows defining both tickers as a single `str`, which will be treated as the value for
-        the `label` key. See :func:`~plot_utils.set_ticks` for more details on the ticker parameters.
+        A short argument form allows defining both tickers labels as a single `str`, which will be treated as the value
+        for the `label` key. See :func:`~plot_utils.set_ticks` for more details on the ticker parameters.
 
         Parameters
         ----------
@@ -1109,15 +1109,15 @@ class Gather:
         ax : matplotlib.axes.Axes, optional, defaults to None
             An axis of the figure to plot on. If not given, it will be created automatically.
         x_tick_src : str, optional
-            Source of the labels to be plotted on x axis. For "seismogram" and "wiggle" can be either "index" (default
+            Source of the tick labels to be plotted on x axis. For "seismogram" and "wiggle" can be either "index" (default
             if gather is not sorted) or any header; for "hist" it also defines the data source and can be either
             "amplitude" (default) or any header.
             Also serves as a default for axis label.
         y_tick_src : str, optional
-            Source of the data to be plotted on y axis. For "seismogram" and "wiggle" can be either "time" (default) or
+            Source of the tick labels to be plotted on y axis. For "seismogram" and "wiggle" can be either "time" (default) or
             "samples"; has no effect in "hist" mode. Also serves as a default for axis label.
         event_headers : str, array-like or dict, optional, defaults to None
-            Only for "seismogram" and "wiggle" modes.
+            Valid only for "seismogram" and "wiggle" modes.
             Headers, whose values will be displayed over the gather plot. Must be measured in milliseconds.
             If `dict`, allows controlling scatter plot options and handling outliers (header values falling out the `y`
             axis range). The following keys are supported:
@@ -1127,11 +1127,11 @@ class Gather:
                 * `discard`: do not display outliers,
                 * `none`: plot all the header values (default behavior).
             - Any additional arguments for `matplotlib.axes.Axes.scatter`.
-            If any dictionary value is array-like, each its element will be associated with the corresponding header.
+            If some dictionary value is array-like, each its element will be associated with the corresponding header.
             Otherwise, the single value will be used for all the scatter plots.
         top_header : str, optional, defaults to None
-            Only for "seismogram" and "wiggle" modes.
-            A header name to plot on top of the gather plot.
+            Valid only for "seismogram" and "wiggle" modes.
+            The name of a header whose values will be plotted on top of the gather plot.
         figsize : tuple, optional, defaults to (10, 7)
             Size of the figure to create if `ax` is not given. Measured in inches.
         save_to : str or dict, optional, defaults to None
@@ -1170,7 +1170,7 @@ class Gather:
         plotters_dict[mode](ax, title=title, x_ticker=x_ticker, y_ticker=y_ticker, **kwargs)
         return self
 
-    def _plot_histogram(self, ax, title=None, x_ticker=None, y_ticker=None, x_tick_src="amplitude", bins=None,
+    def _plot_histogram(self, ax, title, x_ticker, y_ticker, x_tick_src="amplitude", bins=None,
                         log=False, grid=True, **kwargs):
         """Plot histogram of the data scpecified by x_tick_src."""
         data = self.data if x_tick_src=="amplitude" else self[x_tick_src]
@@ -1184,7 +1184,7 @@ class Gather:
         ax.set_title(**{'label': None, **title})
 
     # pylint: disable=too-many-arguments
-    def _plot_seismogram(self, ax, title=None, x_ticker=None, y_ticker=None, x_tick_src=None, y_tick_src='time',
+    def _plot_seismogram(self, ax, title, x_ticker, y_ticker, x_tick_src=None, y_tick_src='time',
                          colorbar=False, qvmin=0.1, qvmax=0.9, event_headers=None, top_header=None, **kwargs):
         """Plot the gather as a 2d grayscale image of seismic traces."""
         # Make the axis divisible to further plot colorbar and header subplot
@@ -1201,7 +1201,7 @@ class Gather:
             ax.figure.colorbar(img, cax=cax, **colorbar)
         self._finalize_plot(ax, title, divider, event_headers, top_header, x_ticker, y_ticker, x_tick_src, y_tick_src)
 
-    def _plot_wiggle(self, ax, title='', x_ticker=None, y_ticker=None, x_tick_src=None, y_tick_src='time',
+    def _plot_wiggle(self, ax, title, x_ticker, y_ticker, x_tick_src=None, y_tick_src='time',
                      std=0.5, color="black", event_headers=None, top_header=None, **kwargs):
         """Plot the gather as an amplitude vs time plot for each trace."""
         # Make the axis divisible to further plot colorbar and header subplot

--- a/seismicpro/src/gather.py
+++ b/seismicpro/src/gather.py
@@ -1067,8 +1067,9 @@ class Gather:
         seismigram or wiggle plot if passed as `event_headers`. If `top_header` is passed, an auxiliary scatter plot of
         values of this header will be shown on top of the gather plot.
 
-        Ticks and their labels for both `x` and `y` axes can be controlled via `x_ticker` and `y_ticker` parameters
-        respectively. In the most general form, each of them is a `dict` with the following most commonly used keys:
+        While the source of label ticks for both `x` and `y` is defined by `x_tick_src` and `y_tick_src`, ticker
+        appearence can be controlled via `x_ticker` and `y_ticker` parameters respectively. In the most general form,
+        each of them is a `dict` with the following most commonly used keys:
         - `label`: axis label. Can be any string.
         - `round_to`: the number of decimal places to round tick labels to (defaults to 0).
         - `rotation`: the rotation angle of tick labels in degrees (defaults to 0).
@@ -1093,29 +1094,27 @@ class Gather:
             If `dict`, should contain keyword arguments to pass to `matplotlib.axes.Axes.set_title`. In this case, the
             title string is stored under the `label` key.
         x_ticker : str or dict, optional, defaults to None
-            Source to get `x` tick labels from and additional parameters to control their formatting and layout.
-            If `str`, either any gather header name to use its values as labels or "index" to use ordinal numbers of
-            traces in the gather.
-            If `dict`, the source is specified under the "labels" key and the rest keys define labels formatting and
-            layout, see :func:`~plot_utils.set_ticks` for more details.
-            If not given, but the gather is sorted, `self.sort_by` will be passed as `x_ticker`. Otherwise, "index"
-            will be passed.
-        y_ticker : "time", "samples" or dict, optional, defaults to "time"
-            Source to get `y` tick labels from and additional parameters to control their formatting and layout.
-            If "time", the labels are the times of gather samples in milliseconds, if "samples" - ordinal numbers of
-            gather samples.
-            If `dict`, stores either "time" or "samples" under the "labels" key and the rest keys define labels
-            formatting and layout, see :func:`~plot_utils.set_ticks` for more details.
+            Parameters to control `x` axis label and ticker formatting and layout.
+            If `str`, it will be displayed as axis label.
+            If `dict`, the axis label is specified under the "label" key and the rest of keys define labels formatting
+            and layout, see :func:`~plot_utils.set_ticks` for more details.
+            If not given, axis label is defined by `x_tick_src`.
+        y_ticker : str or dict, optional, defaults to None
+            Parameters to control `y` axis label and ticker formatting and layout.
+            If `str`, it will be displayed as axis label.
+            If `dict`, the axis label is specified under the "label" key and the rest of keys define labels formatting
+            and layout, see :func:`~plot_utils.set_ticks` for more details.
+            If not given, axis label is defined by `y_tick_src`.
         ax : matplotlib.axes.Axes, optional, defaults to None
             An axis of the figure to plot on. If not given, it will be created automatically.
         x_tick_src : str, optional
-            Source of the tick labels to be plotted on x axis. For "seismogram" and "wiggle" can be either "index" (default
-            if gather is not sorted) or any header; for "hist" it also defines the data source and can be either
-            "amplitude" (default) or any header.
+            Source of the tick labels to be plotted on x axis. For "seismogram" and "wiggle" can be either "index"
+            (default if gather is not sorted) or any header; for "hist" it also defines the data source and can be
+            either "amplitude" (default) or any header.
             Also serves as a default for axis label.
         y_tick_src : str, optional
-            Source of the tick labels to be plotted on y axis. For "seismogram" and "wiggle" can be either "time" (default) or
-            "samples"; has no effect in "hist" mode. Also serves as a default for axis label.
+            Source of the tick labels to be plotted on y axis. For "seismogram" and "wiggle" can be either "time"
+            (default) or "samples"; has no effect in "hist" mode. Also serves as a default for axis label.
         event_headers : str, array-like or dict, optional, defaults to None
             Valid only for "seismogram" and "wiggle" modes.
             Headers, whose values will be displayed over the gather plot. Must be measured in milliseconds.

--- a/seismicpro/src/gather.py
+++ b/seismicpro/src/gather.py
@@ -1161,9 +1161,9 @@ class Gather:
                         grid=True, **kwargs):
         """ TODO """
         data = self.data if x_tick_src=="amplitude" else self[x_tick_src]
-        counts, _, _ = ax.hist(data.ravel(), bins=bins, **kwargs)
+        _ = ax.hist(data.ravel(), bins=bins, **kwargs)
         set_ticks(ax, "x", tick_labels=None, **{"label": x_tick_src, 'round_to': None, **x_ticker})
-        set_ticks(ax, "y", tick_labels=np.arange(0, counts.max()+1), **{"label": "counts", **y_ticker})
+        set_ticks(ax, "y", tick_labels=None, **{"label": "counts", **y_ticker})
 
         ax.grid(grid)
         if log:

--- a/seismicpro/src/gather.py
+++ b/seismicpro/src/gather.py
@@ -1168,8 +1168,7 @@ class Gather:
         }
         if mode not in plotters_dict:
             raise ValueError(f"Unknown mode {mode}")
-        ax = plotters_dict[mode](ax, title=title, x_ticker=x_ticker, y_ticker=y_ticker, **kwargs)
-        ax.set_title(**{'label': None, **title})
+        plotters_dict[mode](ax, title=title, x_ticker=x_ticker, y_ticker=y_ticker, **kwargs)
         return self
 
     def _plot_histogram(self, ax, title=None, x_ticker=None, y_ticker=None, x_tick_src="amplitude", bins=None,

--- a/seismicpro/src/gather.py
+++ b/seismicpro/src/gather.py
@@ -1204,7 +1204,7 @@ class Gather:
         traces = std * (self.data - self.data.mean(axis=1, keepdims=True)) / (np.std(self.data) + 1e-10)
         for i, (trace, col) in enumerate(zip(traces, color)):
             ax.plot(i + trace, y_coords, color=col, **kwargs)
-            ax.fill_betweenx(y_coords, i, i + trace, where=(trace > 0), color=col, **kwargs)
+            ax.fill_betweenx(y_coords, i, i + trace, where=(trace > 0), color=col)
         ax.invert_yaxis()
 
         # Wiggle plot requires custom data interval for correct tick setting

--- a/seismicpro/src/gather.py
+++ b/seismicpro/src/gather.py
@@ -1148,13 +1148,13 @@ class Gather:
                         **kwargs):
         """ TODO """
         data = self.data if x_tick_src=="amplitude" else self[x_tick_src]
-        counts, bins, _ = ax.hist(data.ravel(), bins=bins, **kwargs)
-        set_ticks(ax, "x", tick_labels=(bins[:-1] + np.diff(bins) / 2),
-                  **{"label": x_tick_src, 'round_to': None, **x_ticker})
-        set_ticks(ax, "y", tick_labels=np.arange(0, counts.max()), **{"label": "counts", **y_ticker})
+        counts, _, _ = ax.hist(data.ravel(), bins=bins, **kwargs)
+        set_ticks(ax, "x", tick_labels=None, **{"label": x_tick_src, 'round_to': None, **x_ticker})
+        set_ticks(ax, "y", tick_labels=np.arange(0, counts.max()+1), **{"label": "counts", **y_ticker})
 
         ax.grid(grid)
-        ax.set_yscale("log" if log else "linear")
+        if log:
+            ax.set_yscale("log")
         return ax
 
     def _plot_seismogram(self, ax, colorbar=False, qvmin=0.1, qvmax=0.9, x_ticker=None, y_ticker=None,

--- a/seismicpro/src/gather.py
+++ b/seismicpro/src/gather.py
@@ -16,8 +16,8 @@ from .semblance import Semblance, ResidualSemblance
 from .velocity_cube import StackingVelocity, VelocityCube
 from .decorators import batch_method, plotter
 from .utils import normalization, correction
-from .utils import to_list, convert_times_to_mask, convert_mask_to_pick, mute_gather, make_origins
-from .utils import set_ticks, set_text_formatting
+from .utils import (to_list, convert_times_to_mask, convert_mask_to_pick, times_to_indices, mute_gather, make_origins,
+                    set_ticks, set_text_formatting)
 
 class Gather:
     """A class representing a single seismic gather.

--- a/seismicpro/src/gather.py
+++ b/seismicpro/src/gather.py
@@ -1157,8 +1157,8 @@ class Gather:
         ax.set_title(**{'label': None, **title})
         return self
 
-    def _plot_histogram(self, ax, bins=50, x_tick_src="amplitude", log=False, x_ticker=None, y_ticker=None, grid=False,
-                        **kwargs):
+    def _plot_histogram(self, ax, bins=None, x_tick_src="amplitude", log=False, x_ticker=None, y_ticker=None,
+                        grid=True, **kwargs):
         """ TODO """
         data = self.data if x_tick_src=="amplitude" else self[x_tick_src]
         counts, _, _ = ax.hist(data.ravel(), bins=bins, **kwargs)
@@ -1206,9 +1206,6 @@ class Gather:
             ax.plot(i + trace, y_coords, color=col, **kwargs)
             ax.fill_betweenx(y_coords, i, i + trace, where=(trace > 0), color=col)
         ax.invert_yaxis()
-
-        # Wiggle plot requires custom data interval for correct tick setting
-        x_ticker.update({"tick_range":(0, self.n_traces-1)})
         return self._finalize_plot(ax, divider, event_headers, top_header, x_ticker, y_ticker, x_tick_src, y_tick_src)
 
     def _finalize_plot(self, ax, divider, event_headers, top_header, x_ticker, y_ticker, x_tick_src, y_tick_src):
@@ -1222,7 +1219,7 @@ class Gather:
             top_ax = self._plot_top_subplot(ax=ax, divider=divider, header_values=self[top_header].ravel())
 
         # Set axis ticks
-        x_tick_src = (self.sort_by if self.sort_by is not None else "index") if x_tick_src is None else x_tick_src
+        x_tick_src = x_tick_src or self.sort_by or "index"
         self._set_ticks(ax, axis="x", tick_src=x_tick_src, ticker=x_ticker)
         self._set_ticks(ax, axis="y", tick_src=y_tick_src, ticker=y_ticker)
 

--- a/seismicpro/src/gather.py
+++ b/seismicpro/src/gather.py
@@ -1142,7 +1142,7 @@ class Gather:
         return self
 
     def _plot_histogram(self, bins=50, hist_header=None, log=False, title=None,
-                        x_ticker=None, y_ticker="counts", ax=None, **kwargs):
+                        x_ticker=None, y_ticker="counts", ax=None, grid=False, **kwargs):
         """ TODO """
         data = self.data.ravel() if hist_header is None else self.headers[hist_header].values
 
@@ -1155,10 +1155,11 @@ class Gather:
                 raise ValueError(f"{axis} axis ticker must be str, but {type(axis_label)} passed")
 
             # Get tick_labels depending on axis and its label
-            tick_labels = np.arange(0, counts) if axis=="y" else bins[:-1] + np.diff(bins) / 2
+            tick_labels = np.arange(0, counts.max()) if axis=="y" else (bins[:-1] + np.diff(bins) / 2)
 
             set_ticks(ax, axis, axis_label, tick_labels, **ticker)
 
+        ax.grid(grid)
         if log:
             ax.set_yscale("log")
 
@@ -1189,7 +1190,7 @@ class Gather:
 
         # Wiggle plot requires custom data interval for correct tick setting
         if mode == "wiggle":
-            x_ticker.update({"tick_range":np.arange(self.n_traces)})
+            x_ticker.update({"tick_range":(0, self.n_traces-1)})
 
         # Set axis ticks
         self._set_ticks(ax, axis="x", ticker=x_ticker)

--- a/seismicpro/src/gather.py
+++ b/seismicpro/src/gather.py
@@ -1,6 +1,5 @@
 """Implements Gather class that represents a group of seismic traces that share some common acquisition parameter"""
 
-from email import header
 import os
 import warnings
 from copy import deepcopy

--- a/seismicpro/src/gather.py
+++ b/seismicpro/src/gather.py
@@ -1135,13 +1135,14 @@ class Gather:
             self._plot_histogram(ax=ax, title=title, x_ticker=x_ticker, y_ticker=y_ticker, **kwargs)
         else:
             if x_ticker is None:
-                x_ticker = as_dict((self.sort_by if self.sort_by is not None else "index"), key="label")
+                x_ticker = self.sort_by if self.sort_by is not None else "index"
+            x_ticker = as_dict(x_ticker, key="label")
             y_ticker = as_dict(("time" if y_ticker is None else y_ticker), key="label")
             self._plot_traces(mode, title=title, x_ticker=x_ticker, y_ticker=y_ticker, ax=ax, **kwargs)
         return self
 
     def _plot_histogram(self, bins=50, hist_header=None, log=False, title=None,
-                        x_ticker=None, y_ticker="counts", ax=None, grid=False, **kwargs):
+                        x_ticker=None, y_ticker=None, ax=None, grid=False, **kwargs):
         """ TODO """
         data = self.data.ravel() if hist_header is None else self.headers[hist_header].values
 
@@ -1152,10 +1153,8 @@ class Gather:
             axis_label = ticker.pop("label")
             if not isinstance(axis_label, str):
                 raise ValueError(f"{axis} axis ticker must be str, but {type(axis_label)} passed")
-
             # Get tick_labels depending on axis and its label
             tick_labels = np.arange(0, counts.max()) if axis=="y" else (bins[:-1] + np.diff(bins) / 2)
-
             set_ticks(ax, axis, axis_label, tick_labels, **ticker)
 
         ax.grid(grid)
@@ -1163,7 +1162,7 @@ class Gather:
             ax.set_yscale("log")
 
     def _plot_traces(self, mode, event_headers=None, top_header=None,
-                     title=None, x_ticker=None, y_ticker="time", ax=None, **kwargs):
+                     title=None, x_ticker=None, y_ticker=None, ax=None, **kwargs):
         """ TODO """
         # Make the axis divisible to further plot colorbar and header subplot
         divider = make_axes_locatable(ax)

--- a/seismicpro/src/gather.py
+++ b/seismicpro/src/gather.py
@@ -1140,17 +1140,17 @@ class Gather:
         }
         if mode not in plotters_dict:
             raise ValueError(f"Unknown mode {mode}")
-        ax = plotters_dict[mode](ax, x_ticker, y_ticker, **kwargs)
+        ax = plotters_dict[mode](ax, x_ticker=x_ticker, y_ticker=y_ticker, **kwargs)
         ax.set_title(**{'label': None, **title})
         return self
 
-    def _plot_histogram(self, bins=50, x_tick_src="amplitude", log=False, x_ticker=None, y_ticker=None, grid=False,
-                        ax=None, **kwargs):
+    def _plot_histogram(self, ax, bins=50, x_tick_src="amplitude", log=False, x_ticker=None, y_ticker=None, grid=False,
+                        **kwargs):
         """ TODO """
         data = self.data if x_tick_src=="amplitude" else self[x_tick_src]
         counts, bins, _ = ax.hist(data.ravel(), bins=bins, **kwargs)
-
-        set_ticks(ax, "x", tick_labels=(bins[:-1] + np.diff(bins) / 2), **{"label": x_tick_src, **x_ticker})
+        set_ticks(ax, "x", tick_labels=(bins[:-1] + np.diff(bins) / 2),
+                  **{"label": x_tick_src, 'round_to': None, **x_ticker})
         set_ticks(ax, "y", tick_labels=np.arange(0, counts.max()), **{"label": "counts", **y_ticker})
 
         ax.grid(grid)
@@ -1209,8 +1209,8 @@ class Gather:
 
         # Set axis ticks
         x_tick_src = (self.sort_by if self.sort_by is not None else "index") if x_tick_src is None else x_tick_src
-        self._set_ticks(ax, axis="x", axis_value=x_tick_src, ticker=x_ticker)
-        self._set_ticks(ax, axis="y", axis_value=y_tick_src, ticker=y_ticker)
+        self._set_ticks(ax, axis="x", tick_src=x_tick_src, ticker=x_ticker)
+        self._set_ticks(ax, axis="y", tick_src=y_tick_src, ticker=y_ticker)
 
         return top_ax
 
@@ -1305,4 +1305,4 @@ class Gather:
             tick_labels = self._get_y_ticks(tick_src)
         else:
             raise ValueError(f"Unknown axis {axis}")
-        set_ticks(ax, axis, tick_labels, {"label": tick_src, **ticker})
+        set_ticks(ax, axis, tick_labels=tick_labels, **{"label": tick_src, **ticker})

--- a/seismicpro/src/semblance.py
+++ b/seismicpro/src/semblance.py
@@ -8,7 +8,7 @@ from matplotlib import colors as mcolors
 from .decorators import batch_method, plotter
 from .velocity_model import calculate_stacking_velocity
 from .velocity_cube import StackingVelocity
-from .utils import set_ticks, as_dict
+from .utils import as_dict, set_ticks, set_text_formatting
 from .utils.correction import get_hodograph
 
 
@@ -327,6 +327,8 @@ class Semblance(BaseSemblance):
         semblance : Semblance
             Self unchanged.
         """
+        # Cast text-related parameters to dicts and add text formatting parameters from kwargs to each of them
+        (title, x_ticker, y_ticker), kwargs = set_text_formatting(title, x_ticker, y_ticker, **kwargs)
         # Add a stacking velocity line on the plot
         stacking_times_ix, stacking_velocities_ix = None, None
         if stacking_velocity is not None:
@@ -589,6 +591,8 @@ class ResidualSemblance(BaseSemblance):
         semblance : ResidualSemblance
             Self unchanged.
         """
+        # Cast text-related parameters to dicts and add text formatting parameters from kwargs to each of them
+        (title, x_ticker, y_ticker), kwargs = set_text_formatting(title, x_ticker, y_ticker, **kwargs)
         x_ticklabels = np.linspace(-self.relative_margin, self.relative_margin, self.residual_semblance.shape[1]) * 100
 
         stacking_times = self.stacking_velocity.times if self.stacking_velocity.times is not None else self.times

--- a/seismicpro/src/semblance.py
+++ b/seismicpro/src/semblance.py
@@ -161,6 +161,9 @@ class BaseSemblance:
         kwargs : misc, optional
             Additional common keyword arguments for `x_ticker` and `y_tickers`.
         """
+        # Cast text-related parameters to dicts and add text formatting parameters from kwargs to each of them
+        (title, x_ticker, y_ticker), kwargs = set_text_formatting(title, x_ticker, y_ticker, **kwargs)
+
         # Split the range of semblance amplitudes into 16 levels on a log scale,
         # that will further be used as colormap bins
         max_val = np.max(semblance)
@@ -184,10 +187,8 @@ class BaseSemblance:
         if grid:
             ax.grid(c='k')
 
-        x_ticker = kwargs if x_ticker is None else {**kwargs, **x_ticker}
-        y_ticker = kwargs if y_ticker is None else {**kwargs, **y_ticker}
         set_ticks(ax, "x", x_label, x_ticklabels, **x_ticker)
-        set_ticks(ax, "y", "Time (ms)", y_ticklabels, **y_ticker)
+        set_ticks(ax, "y", "Time", y_ticklabels, **y_ticker)
 
 
 class Semblance(BaseSemblance):
@@ -327,8 +328,6 @@ class Semblance(BaseSemblance):
         semblance : Semblance
             Self unchanged.
         """
-        # Cast text-related parameters to dicts and add text formatting parameters from kwargs to each of them
-        (title, x_ticker, y_ticker), kwargs = set_text_formatting(title, x_ticker, y_ticker, **kwargs)
         # Add a stacking velocity line on the plot
         stacking_times_ix, stacking_velocities_ix = None, None
         if stacking_velocity is not None:
@@ -591,8 +590,6 @@ class ResidualSemblance(BaseSemblance):
         semblance : ResidualSemblance
             Self unchanged.
         """
-        # Cast text-related parameters to dicts and add text formatting parameters from kwargs to each of them
-        (title, x_ticker, y_ticker), kwargs = set_text_formatting(title, x_ticker, y_ticker, **kwargs)
         x_ticklabels = np.linspace(-self.relative_margin, self.relative_margin, self.residual_semblance.shape[1]) * 100
 
         stacking_times = self.stacking_velocity.times if self.stacking_velocity.times is not None else self.times

--- a/seismicpro/src/utils/plot_utils.py
+++ b/seismicpro/src/utils/plot_utils.py
@@ -56,7 +56,7 @@ def set_ticks(ax, axis, label='', tick_labels=None, num=None, step_ticks=None,
         "Time": " (ms)",
         "Offset": " (m)",
     }
-    label = str.capitalize(label)
+    label = label[0].upper() + label[1:]
     label += UNITS.get(label, "")
 
     ax_obj = getattr(ax, f"{axis}axis")

--- a/seismicpro/src/utils/plot_utils.py
+++ b/seismicpro/src/utils/plot_utils.py
@@ -15,20 +15,17 @@ def save_figure(fig, fname, dpi=100, bbox_inches="tight", pad_inches=0.1, **kwar
     """Save the given figure. All `args` and `kwargs` are passed directly into `matplotlib.pyplot.savefig`."""
     fig.savefig(fname, dpi=dpi, bbox_inches=bbox_inches, pad_inches=pad_inches, **kwargs)
 
-
-def set_text_formatting(kwargs):
-    """Pop text formatting args from `kwargs` and set them as defaults for 'title', 'x_ticker' and 'y_ticker'."""
+def set_text_formatting(*args, **kwargs):
+    """Pop text formatting args from `kwargs` and set them as defaults for args transformed to dickts."""
     FORMAT_ARGS = {'fontsize', 'size', 'fontfamily', 'family', 'fontweight', 'weight'}
-    TEXT_ARGS = {'title', 'x_ticker', 'y_ticker'}
 
     global_formatting = {arg: kwargs.pop(arg) for arg in FORMAT_ARGS if arg in kwargs}
-    text_args = {arg: {**global_formatting, **as_dict(kwargs.pop(arg), key="label")}
-                 for arg in TEXT_ARGS if arg in kwargs}
-    return {**kwargs, **text_args}
+    text_args = ({**global_formatting, **({} if arg is None else as_dict(arg, key="label"))}
+                  for arg in args)
+    return text_args, kwargs
 
-
-def set_ticks(ax, axis, axis_label, tick_labels, num=None, step_ticks=None,
-              step_labels=None, round_to=0, tick_range=None, **kwargs):
+def set_ticks(ax, axis, label, tick_labels, num=None, step_ticks=None,
+              step_labels=None, tick_range=None, round_to=0, **kwargs):
     """Set ticks and labels for `x` or `y` axis depending on the `axis`.
 
     Parameters
@@ -59,8 +56,8 @@ def set_ticks(ax, axis, axis_label, tick_labels, num=None, step_ticks=None,
         "time": " (ms)",
         "offset": " (m)",
     }
-    axis_label += UNITS.get(axis_label, "")
-    axis_label = str.capitalize(axis_label)
+    label += UNITS.get(label, "")
+    label = str.capitalize(label)
 
     ax_obj = getattr(ax, f"{axis}axis")
     # The object drawn can have single tick label (e.g., for single-trace `gather`) which leads to interp1d being
@@ -76,7 +73,7 @@ def set_ticks(ax, axis, axis_label, tick_labels, num=None, step_ticks=None,
     locator, formatter = _process_ticks(labels=tick_labels, num=num, step_ticks=step_ticks, step_labels=step_labels,
                                         round_to=round_to, tick_interpolator=tick_interpolator)
     rotation_kwargs = _pop_rotation_kwargs(kwargs)
-    ax_obj.set_label_text(axis_label, **kwargs)
+    ax_obj.set_label_text(label, **kwargs)
     ax_obj.set_ticklabels([], **kwargs, **rotation_kwargs)
     ax_obj.set_major_locator(locator)
     ax_obj.set_major_formatter(formatter)

--- a/seismicpro/src/utils/plot_utils.py
+++ b/seismicpro/src/utils/plot_utils.py
@@ -62,8 +62,9 @@ def set_ticks(ax, axis, label='', tick_labels=None, num=None, step_ticks=None,
     ax_obj = getattr(ax, f"{axis}axis")
     rotation_kwargs = _pop_rotation_kwargs(kwargs)
     ax_obj.set_label_text(label, **kwargs)
-    ax_obj.set_tick_params(**kwargs, **rotation_kwargs)
-    if tick_labels is not None:
+    if tick_labels is None:
+        locator, formatter = ticker.AutoLocator(), ticker.ScalarFormatter()
+    else:
         # The object drawn can have single tick label (e.g., for single-trace `gather`) which leads to interp1d being
         # unable to initiate since both x and y should have at least 2 entries. Repeating this single label solves the
         # issue.
@@ -77,10 +78,9 @@ def set_ticks(ax, axis, label='', tick_labels=None, num=None, step_ticks=None,
                                      kind="nearest", bounds_error=False)
         locator, formatter = _process_ticks(labels=tick_labels, num=num, step_ticks=step_ticks, step_labels=step_labels,
                                             round_to=round_to, tick_interpolator=tick_interpolator)
-
-        ax_obj.set_ticklabels([])
-        ax_obj.set_major_locator(locator)
-        ax_obj.set_major_formatter(formatter)
+    ax_obj.set_ticklabels([], **kwargs, **rotation_kwargs)
+    ax_obj.set_major_locator(locator)
+    ax_obj.set_major_formatter(formatter)
 
 
 def _process_ticks(labels, num, step_ticks, step_labels, round_to, tick_interpolator):

--- a/seismicpro/src/utils/plot_utils.py
+++ b/seismicpro/src/utils/plot_utils.py
@@ -18,7 +18,7 @@ def save_figure(fig, fname, dpi=100, bbox_inches="tight", pad_inches=0.1, **kwar
 
 def set_text_formatting(*args, **kwargs):
     """Pop text formatting parameters from `kwargs` and set them as defaults for each of `args` tranformed to dict."""
-    FORMAT_ARGS = {'fontsize', 'size', 'fontfamily', 'family', 'fontweight', 'weight'}
+    FORMAT_ARGS = {'fontsize', 'fontfamily', 'fontweight'}
 
     global_formatting = {arg: kwargs.pop(arg) for arg in FORMAT_ARGS if arg in kwargs}
     text_args = ({**global_formatting, **({} if arg is None else as_dict(arg, key="label"))} for arg in args)
@@ -68,10 +68,10 @@ def set_ticks(ax, axis, label='', tick_labels=None, num=None, step_ticks=None, s
     label = label[0].upper() + label[1:]
     label += UNITS.get(label, "")
 
-    ax_obj = getattr(ax, f"{axis}axis")
     locator, formatter = _process_ticks(labels=tick_labels, num=num, step_ticks=step_ticks,
                                         step_labels=step_labels, round_to=round_to)
     rotation_kwargs = _pop_rotation_kwargs(kwargs)
+    ax_obj = getattr(ax, f"{axis}axis")
     ax_obj.set_label_text(label, **kwargs)
     ax_obj.set_ticklabels([], **kwargs, **rotation_kwargs)
     ax_obj.set_major_locator(locator)


### PR DESCRIPTION
Changes summary:
* `gather.plot` with `'hist'` mode can plot histograms of gather data amplitudes or gather's header values;
* now `gather.plot` has `x_tick_src` \ `y_tick_src` parameters that indicate the data source and default label for said axes; `'label'` key of `x\y_ticker` parameter now only controls axis label and can overwrite default provided by `x\y_tick_src`;
* text formatting was moved from `@plotter` decorator to the body of corresponding plot methods, since only plot methods know which of their arguments should be treated as text parameters.
* `None` value is now allowed for `tick_labels` in `set_ticks` function; in this case, all the formatting and locating options (except for `step_labels`, for obvious reasons) are applied to default ticks;


Also, fixed of a small bug in `batch.plot`.