### PR TITLE
fix speed, add test params

### DIFF
--- a/seismicpro/src/survey.py
+++ b/seismicpro/src/survey.py
@@ -5,6 +5,7 @@ import os
 import warnings
 from copy import copy, deepcopy
 from textwrap import dedent
+import math
 
 import segyio
 import numpy as np
@@ -384,7 +385,7 @@ class Survey:  # pylint: disable=too-many-instance-attributes
             self.load_trace(buf=trace, index=pos, limits=limits, trace_length=n_samples)
             trace_min, trace_max, *_ = calculate_stats(trace)
 
-            if np.isclose(trace_min, trace_max):
+            if math.isclose(trace_min, trace_max):
                 dead_indices.append(tr_index)
 
         self.n_dead_traces = len(dead_indices)

--- a/seismicpro/src/tests/survey/test_stats.py
+++ b/seismicpro/src/tests/survey/test_stats.py
@@ -118,16 +118,20 @@ class TestStats:
             survey.get_quantile(0.5)
 
 
-
+@pytest.mark.parametrize("header_index", ["TRACE_SEQUENCE_FILE", "CDP", ["CDP", "FieldRecord"]])
 class TestDeadTraces:
     """Test dead traces processing"""
     @pytest.mark.parametrize("inplace", [True, False])
     @pytest.mark.parametrize("pre_mark_dead", [True, False])
-    def test_remove(self, stat_segy, inplace, pre_mark_dead):
+    def test_remove(self, stat_segy, header_index, inplace, pre_mark_dead):
         """Check that `remove_dead_traces` properly updates survey `headers` and sets `n_dead_traces` counter to 0."""
 
         path, trace_data = stat_segy
-        survey = Survey(path, header_index="TRACE_SEQUENCE_FILE", header_cols="offset")
+        survey = Survey(path, header_index=header_index, header_cols="offset")
+
+        traces_pos = survey.headers.reset_index()["TRACE_SEQUENCE_FILE"].values - 1
+        trace_data = trace_data[np.argsort(traces_pos)]
+
         survey_copy = survey.copy()
 
         if pre_mark_dead:
@@ -147,11 +151,15 @@ class TestDeadTraces:
         assert_survey_processed_inplace(survey, survey_filtered, inplace)
 
     @pytest.mark.parametrize("detection_limits", [None, slice(5), slice(2, 8)])
-    def test_mark(self, stat_segy, detection_limits):
+    def test_mark(self, stat_segy, header_index, detection_limits):
         """Check that `mark_dead_traces` properly updates survey `headers` and sets `n_dead_traces` counter."""
 
         path, trace_data = stat_segy
-        survey = Survey(path, header_index="TRACE_SEQUENCE_FILE", header_cols="offset")
+        survey = Survey(path, header_index=header_index, header_cols="offset")
+
+        traces_pos = survey.headers.reset_index()["TRACE_SEQUENCE_FILE"].values - 1
+        trace_data = trace_data[np.argsort(traces_pos)]
+
         survey_copy = survey.copy()
 
         survey.mark_dead_traces(limits=detection_limits, bar=False)
@@ -160,8 +168,7 @@ class TestDeadTraces:
             trace_data = trace_data[:, detection_limits]
 
         is_dead = np.isclose(trace_data.min(axis=1), trace_data.max(axis=1))
-        survey_copy.headers[HDR_DEAD_TRACE] = False
-        survey_copy.headers.loc[is_dead, HDR_DEAD_TRACE] = True
+        survey_copy.headers[HDR_DEAD_TRACE] = is_dead
         survey_copy.n_dead_traces = np.sum(is_dead)
 
         assert_surveys_equal(survey, survey_copy)


### PR DESCRIPTION
Dead traces detection works slowly compared to `collect_stats` due to slow work of `np.isclose` for scalars (https://github.com/numpy/numpy/issues/16160) 

I've replaced np.isclose with math.isclose in `mark_dead_traces` and added various survey indices in dead traces related tests

 here (https://github.com/numpy/numpy/issues/10161) some differences in np.isclose and math.isclose are discussed
