### PR TITLE
Faster and clearer wiggle plot

### DIFF
--- a/seismicpro/src/gather/gather.py
+++ b/seismicpro/src/gather/gather.py
@@ -1300,7 +1300,7 @@ class Gather(TraceContainer, SamplesContainer):
 
     #pylint: disable=invalid-name
     def _plot_wiggle(self, ax, title, x_ticker, y_ticker, x_tick_src=None, y_tick_src="time", norm_tracewise=True,
-                     std=0.5, event_headers=None, top_header=None, lw=None, alpha=None, color='k', **kwargs):
+                     std=0.5, event_headers=None, top_header=None, lw=None, alpha=None, color="black", **kwargs):
         """Plot the gather as an amplitude vs time plot for each trace."""
         # Make the axis divisible to further plot colorbar and header subplot
         divider = make_axes_locatable(ax)

--- a/seismicpro/src/gather/gather.py
+++ b/seismicpro/src/gather/gather.py
@@ -1309,12 +1309,12 @@ class Gather(TraceContainer, SamplesContainer):
         # axes(by default created by gather.plot()). Scale this parameters linearly for bigger gathers or smaller axes.
         axes_width = ax.get_window_extent().transformed(ax.figure.dpi_scale_trans.inverted()).width
 
-        MAX_TRACE_DENSITY = 150 / 7.75 # N_TRACES / N_INCHES
-        BOUNDS = [[0.25, 1], [0, 1]]
+        MAX_TRACE_DENSITY = 150 / 7.75
+        BOUNDS = [[0.25, 1], [0, 1.5]] # The clip limits for parameters after linear scale.
 
-        alpha, lw = [np.clip(MAX_TRACE_DENSITY * (axes_width / self.n_traces), *val_bounds) if val is None else val 
+        alpha, lw = [np.clip(MAX_TRACE_DENSITY * (axes_width / self.n_traces), *val_bounds) if val is None else val
                      for val, val_bounds in zip([alpha, lw], BOUNDS)]
-        
+
         std_axis = 1 if norm_tracewise else None
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", category=RuntimeWarning)
@@ -1325,13 +1325,15 @@ class Gather(TraceContainer, SamplesContainer):
         amps = traces + np.arange(traces.shape[0]).reshape(-1, 1)
         # Plot all the traces as one Line, then hide transitions between adjacanet traces
         amps = np.concatenate([amps, np.full((len(amps), 1), np.nan)], axis=1)
-        ax.plot(amps.ravel(), np.broadcast_to(np.arange(amps.shape[1]), amps.shape).ravel(), color=color, lw=lw, **kwargs)
+        ax.plot(amps.ravel(), np.broadcast_to(np.arange(amps.shape[1]), amps.shape).ravel(),
+                color=color, lw=lw, **kwargs)
 
         # Find polygons bodies:  indices of target amplitudes, start and end
         poly_amp_ix = np.argwhere(traces > 0)
-        start_ix = np.argwhere(np.diff(poly_amp_ix[:, 1], prepend=poly_amp_ix[0, 1]) != 1).ravel()
-        end_ix = start_ix + np.diff(start_ix, append=len(poly_amp_ix))
-        
+        start_ix = np.argwhere(np.diff(poly_amp_ix[:, 0], prepend=poly_amp_ix[0, 0]) == 0 &
+                               np.diff(poly_amp_ix[:, 1], prepend=poly_amp_ix[0, 1]) != 1).ravel()
+        end_ix = start_ix + np.diff(start_ix, append=len(poly_amp_ix)) - 1
+
         shift = np.arange(len(start_ix)) * 3
         # For each polygon we need to:
         # 1. insert 0 amplitude at the start.
@@ -1340,18 +1342,18 @@ class Gather(TraceContainer, SamplesContainer):
         # Fill the array storing resulted polygons
         verts = np.empty((len(poly_amp_ix) + 3 * len(start_ix) , 2))
         verts[start_ix + shift] = poly_amp_ix[start_ix]
-        verts[end_ix + shift + 1] = poly_amp_ix[end_ix - 1]
-        verts[end_ix + shift + 2] = poly_amp_ix[start_ix]
+        verts[end_ix + shift + 2] = poly_amp_ix[end_ix ]
+        verts[end_ix + shift + 3] = poly_amp_ix[start_ix]
 
-        ix_amps = np.setdiff1d(np.arange(len(verts)), 
-                               np.concatenate([start_ix + shift, end_ix + shift + 1, end_ix + shift + 2]), 
+        ix_amps = np.setdiff1d(np.arange(len(verts)),
+                               np.concatenate([start_ix + shift, end_ix + shift + 2, end_ix + shift + 3]),
                                assume_unique=True)
         verts[ix_amps] = np.column_stack([amps[tuple(poly_amp_ix.T)], poly_amp_ix[:, 1]])
 
         # Fill the array representing the nodes codes: either start, intermediate or end code.
         codes = np.full(len(verts), Path.LINETO)
         codes[start_ix + shift] = Path.MOVETO
-        codes[end_ix + shift + 2] = Path.CLOSEPOLY
+        codes[end_ix + shift + 3] = Path.CLOSEPOLY
 
         patch = PathPatch(Path(verts, codes), color=color, alpha=alpha)
         ax.add_patch(patch)

--- a/seismicpro/src/gather/gather.py
+++ b/seismicpro/src/gather/gather.py
@@ -1300,7 +1300,7 @@ class Gather(TraceContainer, SamplesContainer):
 
     #pylint: disable=invalid-name
     def _plot_wiggle(self, ax, title, x_ticker, y_ticker, x_tick_src=None, y_tick_src="time", norm_tracewise=True,
-                     std=0.5, event_headers=None, top_header=None, lw=None, alpha=None, color='k', **kwargs): 
+                     std=0.5, event_headers=None, top_header=None, lw=None, alpha=None, color='k', **kwargs):
         """Plot the gather as an amplitude vs time plot for each trace."""
         # Make the axis divisible to further plot colorbar and header subplot
         divider = make_axes_locatable(ax)
@@ -1319,7 +1319,7 @@ class Gather(TraceContainer, SamplesContainer):
         # Estimate values for Polygons transperency and Lines width
         axes_width_inches = ax.get_window_extent().transformed(ax.figure.dpi_scale_trans.inverted()).width
 
-        FINE_RATIO = 150 / 7.75 # N_TRACES / N_INCHES 
+        FINE_RATIO = 150 / 7.75 # N_TRACES / N_INCHES
         FINE_ALPHA_MIN = 0.25 # value from [0, 1]
 
         alpha, lw = [FINE_RATIO * (axes_width_inches / len(traces)) if val is None else val for val in [alpha, lw]]
@@ -1332,24 +1332,23 @@ class Gather(TraceContainer, SamplesContainer):
         # find indices of Polygons boarders
         boarders = np.argwhere(np.diff(xy[:, 1]) != 1).flatten()
 
+        verts = np.empty((len(xy) + 3 * len(boarders) + 3, 2))
         # for each polygon we need to:
         # 1. insert 0 amplitude at the start.
         # 2. append 0 amplitude to the end.
         # 3. append the start point to the end to close polygon.
         # find indices of these points
         shifted_boarders = boarders + np.arange(1, len(boarders) * 3 + 1, 3)
-        ix_start = [0, *shifted_boarders + 3] 
-        ix_end = [*shifted_boarders + 1, -2]
-        ix_close = [*shifted_boarders + 2, -1]
+        ix_start = [0, *shifted_boarders + 3]
+        ix_end = [*shifted_boarders + 1, len(verts) - 3]
+        ix_close = [*shifted_boarders + 2, len(verts) - 2]
+        ix_amps = list(set(range(len(verts))) - set(ix_start) - set(ix_end) - set(ix_close))
 
-        # fill the array representing the Polygons nodes - (x , y) coords
-        verts = np.empty((len(xy) + 3 * len(boarders) + 3, 2))
+        # fill the array representing the Polygons nodes - (x,y) coords
         verts[ix_start] = xy[[0, *boarders + 1]]
         verts[ix_end] = xy[[*boarders, -1]]
         verts[ix_close] = verts[ix_start]
-
-        ix_amps = set(range(len(verts))) - set(ix_start) - set(ix_end) - set(ix_close)
-        verts[list(ix_amps)] = np.column_stack([positive_amps, xy[:, 1]])
+        verts[ix_amps] = np.column_stack([positive_amps, xy[:, 1]])
 
         # fill the array representing the nodes codes: either start, intermediate or end code.
         codes = np.full(len(verts), Path.LINETO)

--- a/seismicpro/src/gather/gather.py
+++ b/seismicpro/src/gather/gather.py
@@ -1340,7 +1340,7 @@ class Gather(TraceContainer, SamplesContainer):
         # 2. append 0 amplitude to the end.
         # 3. append the start point to the end to close polygon.
         # Fill the array storing resulted polygons
-        verts = np.empty((len(poly_amp_ix) + 3 * len(start_ix) , 2))
+        verts = np.empty((len(poly_amp_ix) + 3 * len(start_ix), 2))
         verts[start_ix + shift] = poly_amp_ix[start_ix]
         verts[end_ix + shift + 2] = poly_amp_ix[end_ix]
         verts[end_ix + shift + 3] = poly_amp_ix[start_ix]

--- a/seismicpro/src/gather/gather.py
+++ b/seismicpro/src/gather/gather.py
@@ -1330,8 +1330,8 @@ class Gather(TraceContainer, SamplesContainer):
 
         # Find polygons bodies:  indices of target amplitudes, start and end
         poly_amp_ix = np.argwhere(traces > 0)
-        start_ix = np.argwhere(np.diff(poly_amp_ix[:, 0], prepend=poly_amp_ix[0, 0]) == 0 &
-                               np.diff(poly_amp_ix[:, 1], prepend=poly_amp_ix[0, 1]) != 1).ravel()
+        start_ix = np.argwhere((np.diff(poly_amp_ix[:, 0], prepend=poly_amp_ix[0, 0]) != 0) |
+                               (np.diff(poly_amp_ix[:, 1], prepend=poly_amp_ix[0, 1]) != 1)).ravel()
         end_ix = start_ix + np.diff(start_ix, append=len(poly_amp_ix)) - 1
 
         shift = np.arange(len(start_ix)) * 3
@@ -1342,13 +1342,13 @@ class Gather(TraceContainer, SamplesContainer):
         # Fill the array storing resulted polygons
         verts = np.empty((len(poly_amp_ix) + 3 * len(start_ix) , 2))
         verts[start_ix + shift] = poly_amp_ix[start_ix]
-        verts[end_ix + shift + 2] = poly_amp_ix[end_ix ]
+        verts[end_ix + shift + 2] = poly_amp_ix[end_ix]
         verts[end_ix + shift + 3] = poly_amp_ix[start_ix]
 
-        ix_amps = np.setdiff1d(np.arange(len(verts)),
+        body_ix = np.setdiff1d(np.arange(len(verts)),
                                np.concatenate([start_ix + shift, end_ix + shift + 2, end_ix + shift + 3]),
                                assume_unique=True)
-        verts[ix_amps] = np.column_stack([amps[tuple(poly_amp_ix.T)], poly_amp_ix[:, 1]])
+        verts[body_ix] = np.column_stack([amps[tuple(poly_amp_ix.T)], poly_amp_ix[:, 1]])
 
         # Fill the array representing the nodes codes: either start, intermediate or end code.
         codes = np.full(len(verts), Path.LINETO)


### PR DESCRIPTION
1. Fasten plot by using custom `Artists` to plot the same figures.
2. Add default estimation for `lw` and `alpha` parameters which heavily affect how gather is being plotted.

On the left `gather.plot(mode='wiggle)` from master, on the right the same call from this PR. Note the computational times in the titles.
![O3_YAGOD](https://user-images.githubusercontent.com/8656643/177160385-b7093720-62c4-4043-8bfb-2c719cb2a82e.png)
![H2_PAL](https://user-images.githubusercontent.com/8656643/177160389-fec7b897-9e4d-409d-b2d7-38c70fc450b8.png)

