### PR TITLE
Bump matplotlib version

### DIFF
--- a/seismicpro/gather/gather.py
+++ b/seismicpro/gather/gather.py
@@ -1411,7 +1411,7 @@ class Gather(TraceContainer, SamplesContainer):
         codes[end_ix + shift + 3] = Path.CLOSEPOLY
 
         patch = PathPatch(Path(verts, codes), color=color, alpha=alpha)
-        ax.add_patch(patch)
+        ax.add_artist(patch)
         ax.update_datalim([(0, 0), traces.shape])
         if not ax.yaxis_inverted():
             ax.invert_yaxis()


### PR DESCRIPTION
`gather.plot(mode='wiggle')` takes 15sec to execute for `matplotlib==3.6.1`

The matplotlib artist represening our wiggle curve is `Path`.  Starting [from](https://github.com/matplotlib/matplotlib/pull/19214),  slow fancy logic used for this artist to`autoscale`. 
It scales linearly with `len(Path)` , we have `len(Path) ~ gather.n_times * gather.n_traces`.

Temproary disable `autoscale` via not optimal `add_artist` API, waiting for proper [API](https://github.com/matplotlib/matplotlib/pull/15595) to release