### PR TITLE
Return a 1d-array for a single header selection 

### DIFF
--- a/benchmark/utils.py
+++ b/benchmark/utils.py
@@ -20,7 +20,7 @@ def make_benchmark_data(path):
     # Load headers and add synthetic FirstBreak times
     sur = Survey(path, header_index=['INLINE_3D', 'CROSSLINE_3D'],
                  header_cols='offset', name='raw')
-    sur['FirstBreak'] = np.abs(sur['offset'].ravel() / 1.5 + np.random.normal(0, 30, size=sur.n_traces))
+    sur['FirstBreak'] = np.abs(sur['offset'] / 1.5 + np.random.normal(0, 30, size=sur.n_traces))
 
     def edge_lines_filter(line, num_lines):
         return (line >= line.min() + num_lines) & (line <= line.max() - num_lines)

--- a/seismicpro/containers.py
+++ b/seismicpro/containers.py
@@ -12,7 +12,7 @@ import numpy as np
 import pandas as pd
 
 from .decorators import batch_method
-from .utils import to_list, get_cols, set_cols, create_indexer, maybe_copy
+from .utils import to_list, get_cols, create_indexer, maybe_copy
 
 
 class SamplesContainer:
@@ -63,7 +63,7 @@ class TraceContainer:
 
         Returns
         -------
-        result : 2d np.ndarray
+        result : np.ndarray
             Headers values.
         """
         return get_cols(self.headers, key)
@@ -78,7 +78,7 @@ class TraceContainer:
         value : np.ndarray
             Headers values to set.
         """
-        return set_cols(self.headers, key, value)
+        self.headers[key] = value
 
     def copy(self, ignore=None):
         """Perform a deepcopy of all attributes of `self` except for those specified in `ignore`, which are kept

--- a/seismicpro/containers.py
+++ b/seismicpro/containers.py
@@ -12,7 +12,7 @@ import numpy as np
 import pandas as pd
 
 from .decorators import batch_method
-from .utils import to_list, get_cols, create_indexer, maybe_copy
+from .utils import to_list, get_cols, set_cols, create_indexer, maybe_copy
 
 
 class SamplesContainer:
@@ -53,11 +53,8 @@ class TraceContainer:
         return len(self.headers)
 
     def __getitem__(self, key):
-        """Select values of headers by their names.
-
-        Notes
-        -----
-        A 2d array is always returned even for a single header.
+        """Select values of trace headers by their names. Unlike `pandas` indexing allows for selection of headers the
+        container is indexed by. The returned array will be 1d if a single header is selected and 2d otherwise.
 
         Parameters
         ----------
@@ -69,7 +66,7 @@ class TraceContainer:
         result : 2d np.ndarray
             Headers values.
         """
-        return get_cols(self.headers, to_list(key))
+        return get_cols(self.headers, key)
 
     def __setitem__(self, key, value):
         """Set given values to selected headers.
@@ -81,9 +78,7 @@ class TraceContainer:
         value : np.ndarray
             Headers values to set.
         """
-        key = to_list(key)
-        val = pd.DataFrame(value, columns=key, index=self.headers.index)
-        self.headers[key] = val
+        return set_cols(self.headers, key, value)
 
     def copy(self, ignore=None):
         """Perform a deepcopy of all attributes of `self` except for those specified in `ignore`, which are kept
@@ -126,7 +121,7 @@ class TraceContainer:
             passed as a single arg. If `axis` is `None` and `unpack_args` is `True`, columns of the `df` are passed to
             the `func` as individual arguments.
         kwargs : misc, optional
-            Additional keyword arguments to pass to `func` or `pd.DataFrame.apply`.
+            Additional keyword arguments to be passed to `func` or `pd.DataFrame.apply`.
 
         Returns
         -------
@@ -138,15 +133,14 @@ class TraceContainer:
             res = func(*args, **kwargs)
         else:
             # FIXME: Workaround for a pandas bug https://github.com/pandas-dev/pandas/issues/34822
-            # raw=True causes incorrect apply behavior when axis=1 and several values are returned from `func`
+            # raw=True causes incorrect apply behavior when axis=1 and multiple values are returned from `func`
             raw = (axis != 1)
 
             apply_func = (lambda args, **kwargs: func(*args, **kwargs)) if unpack_args else func
             res = df.apply(apply_func, axis=axis, raw=raw, result_type="expand", **kwargs)
 
-        if isinstance(res, pd.Series):
-            res = res.to_frame()
-        return res.values
+        # Convert np.ndarray/pd.Series/pd.DataFrame outputs from `func` to a 2d array
+        return pd.DataFrame(res).to_numpy()
 
     def _post_filter(self, mask):
         """Implement extra filtering logic of concrete subclass attributes if some of them should also be filtered
@@ -183,7 +177,7 @@ class TraceContainer:
         inplace : bool, optional, defaults to False
             Whether to perform filtering inplace or process a copy.
         kwargs : misc, optional
-            Additional keyword arguments to pass to `cond` or `pd.DataFrame.apply`.
+            Additional keyword arguments to be passed to `cond` or `pd.DataFrame.apply`.
 
         Returns
         -------
@@ -242,7 +236,7 @@ class TraceContainer:
         inplace : bool, optional, defaults to False
             Whether to apply the function inplace or to a copy.
         kwargs : misc, optional
-            Additional keyword arguments to pass to `func` or `pd.DataFrame.apply`.
+            Additional keyword arguments to be passed to `func` or `pd.DataFrame.apply`.
 
         Returns
         -------

--- a/seismicpro/gather/gather.py
+++ b/seismicpro/gather/gather.py
@@ -104,7 +104,7 @@ class Gather(TraceContainer, SamplesContainer):
     @property
     def offsets(self):
         """1d np.ndarray of floats: The distance between source and receiver for each trace. Measured in meters."""
-        return self["offset"].ravel()
+        return self["offset"]
 
     @property
     def shape(self):
@@ -132,20 +132,22 @@ class Gather(TraceContainer, SamplesContainer):
         Notes
         -----
         1. If the data after `__getitem__` is no longer sorted, `sort_by` attribute in the resulting `Gather` will be
-        set to `None`.
-        2. If headers selection is performed, a 2d array is always returned even for a single header.
+           set to `None`.
+        2. If headers selection is performed, the returned array will be 1d if a single header is selected and 2d
+           otherwise.
 
         Parameters
         ----------
         key : str, list of str, int, list, tuple, slice
-            If str or list of str, gather headers to get as a 2d np.ndarray.
+            If str or list of str, gather headers to get as an `np.ndarray`. The returned array is 1d if a single
+            header is selected and 2d otherwise.
             Otherwise, indices of traces and samples to get. In this case, __getitem__ behavior almost coincides with
-            np.ndarray indexing and slicing except for cases, when resulting ndim is not preserved or joint indexation
-            of gather attributes becomes ambiguous (e.g. gather[[0, 1], [0, 1]]).
+            `np.ndarray` indexing and slicing except for cases, when resulting ndim is not preserved or joint
+            indexation of gather attributes becomes ambiguous (e.g. gather[[0, 1], [0, 1]]).
 
         Returns
         -------
-        result : 2d np.ndarray or Gather
+        result : np.ndarray or Gather
             Headers values or Gather with a specified subset of traces and samples.
 
         Raises
@@ -319,7 +321,7 @@ class Gather(TraceContainer, SamplesContainer):
 
         sample_rate = np.int32(self.sample_rate * 1000) # Convert to microseconds
         # Remember ordinal numbers of traces in the parent SEG-Y file to further copy their headers
-        trace_ids = self["TRACE_SEQUENCE_FILE"].ravel() - 1
+        trace_ids = self["TRACE_SEQUENCE_FILE"] - 1
 
         # Keep only headers, defined by SEG-Y standard.
         used_header_names = (set(to_list(self.indexed_by)) | set(self.headers.columns)) & set(segyio.tracefield.keys)
@@ -570,7 +572,7 @@ class Gather(TraceContainer, SamplesContainer):
         gather : Gather
             A new `Gather` with calculated first breaks mask in its `data` attribute.
         """
-        mask = convert_times_to_mask(times=self[first_breaks_col].ravel(), samples=self.samples).astype(np.int32)
+        mask = convert_times_to_mask(times=self[first_breaks_col], samples=self.samples).astype(np.int32)
         gather = self.copy(ignore='data')
         gather.data = mask
         return gather
@@ -698,9 +700,9 @@ class Gather(TraceContainer, SamplesContainer):
         rv : RefractorVelocity
             Constructed near-surface velocity model.
         """
-        return RefractorVelocity.from_first_breaks(self.offsets, self[first_breaks_col].ravel(), init, bounds,
-                                                   n_refractors, max_offset, min_velocity_step, min_refractor_size,
-                                                   loss, huber_coef, tol, coords=self.coords, **kwargs)
+        return RefractorVelocity.from_first_breaks(self.offsets, self[first_breaks_col], init, bounds, n_refractors,
+                                                   max_offset, min_velocity_step, min_refractor_size, loss, huber_coef,
+                                                   tol, coords=self.coords, **kwargs)
 
     #------------------------------------------------------------------------#
     #                         Gather muting methods                          #
@@ -853,9 +855,8 @@ class Gather(TraceContainer, SamplesContainer):
         trace_delays = delay - refractor_velocity(self.offsets)
         trace_delays_samples = times_to_indices(trace_delays, self.samples, round=True).astype(int)
         self.data = correction.apply_lmo(self.data, trace_delays_samples, fill_value)
-        event_headers = [] if event_headers is None else to_list(event_headers)
-        for header in event_headers:
-            self[header] += trace_delays.reshape(-1, 1)
+        if event_headers is not None:
+            self[to_list(event_headers)] += trace_delays.reshape(-1, 1)
         return self
 
     @batch_method(target="threads", args_to_unpack="stacking_velocity")
@@ -924,7 +925,7 @@ class Gather(TraceContainer, SamplesContainer):
             raise TypeError(f'`by` should be str, not {type(by)}')
         if self.sort_by == by:
             return self
-        order = np.argsort(self[by].ravel(), kind='stable')
+        order = np.argsort(self[by], kind='stable')
         self.sort_by = by
         self.data = self.data[order]
         self.headers = self.headers.iloc[order]
@@ -943,8 +944,8 @@ class Gather(TraceContainer, SamplesContainer):
         self : Gather
             `self` with only traces from the central CDP gather kept. Updates `self.headers` and `self.data` inplace.
         """
-        mask = np.all(self["INLINE_3D", "CROSSLINE_3D"] == self["SUPERGATHER_INLINE_3D", "SUPERGATHER_CROSSLINE_3D"],
-                      axis=1)
+        line_cols = self["INLINE_3D", "CROSSLINE_3D", "SUPERGATHER_INLINE_3D", "SUPERGATHER_CROSSLINE_3D"]
+        mask = (line_cols[:, :2] == line_cols[:, 2:]).all(axis=1)
         self.headers = self.headers.loc[mask]
         self.data = self.data[mask]
         return self
@@ -1331,8 +1332,8 @@ class Gather(TraceContainer, SamplesContainer):
     def _plot_histogram(self, ax, title, x_ticker, y_ticker, x_tick_src="amplitude", bins=None,
                         log=False, grid=True, **kwargs):
         """Plot histogram of the data specified by x_tick_src."""
-        data = self.data if x_tick_src == "amplitude" else self[x_tick_src]
-        _ = ax.hist(data.ravel(), bins=bins, **kwargs)
+        data = self.data.ravel() if x_tick_src == "amplitude" else self[x_tick_src]
+        _ = ax.hist(data, bins=bins, **kwargs)
         set_ticks(ax, "x", tick_labels=None, **{"label": x_tick_src, 'round_to': None, **x_ticker})
         set_ticks(ax, "y", tick_labels=None, **{"label": "counts", **y_ticker})
 
@@ -1427,8 +1428,7 @@ class Gather(TraceContainer, SamplesContainer):
         # Add a top subplot for given header if needed and set plot title
         top_ax = ax
         if top_header is not None:
-            top_ax = self._plot_top_subplot(ax=ax, divider=divider, header_values=self[top_header].ravel(),
-                                            y_ticker=y_ticker)
+            top_ax = self._plot_top_subplot(ax=ax, divider=divider, header_values=self[top_header], y_ticker=y_ticker)
 
         # Set axis ticks
         x_tick_src = x_tick_src or self.sort_by or "index"
@@ -1483,7 +1483,7 @@ class Gather(TraceContainer, SamplesContainer):
             header = kwargs.pop("headers")
             label = kwargs.pop("label", header)
             process_outliers = kwargs.pop("process_outliers", "none")
-            y_coords = times_to_indices(self[header].ravel(), self.samples, round=False)
+            y_coords = times_to_indices(self[header], self.samples, round=False)
             if process_outliers == "clip":
                 y_coords = np.clip(y_coords, 0, self.n_samples - 1)
             elif process_outliers == "discard":
@@ -1507,11 +1507,9 @@ class Gather(TraceContainer, SamplesContainer):
 
     def _get_x_ticks(self, axis_label):
         """Get tick labels for x-axis: either any gather header or ordinal numbers of traces in the gather."""
-        if axis_label in self.headers.columns:
-            return self[axis_label].reshape(-1)
         if axis_label == "index":
             return np.arange(self.n_traces)
-        raise ValueError(f"Unknown label for x axis {axis_label}")
+        return self[axis_label]
 
     def _get_y_ticks(self, axis_label):
         """Get tick labels for y-axis: either time samples or ordinal numbers of samples in the gather."""

--- a/seismicpro/gather/metrics.py
+++ b/seismicpro/gather/metrics.py
@@ -28,8 +28,10 @@ class FirstBreaksOutliers(PipelineMetric):
 
         Parameters
         ----------
+        gather : Gather
+            A seismic gather to get offsets and first break times from.
         refractor_velocity : RefractorVelocity
-            RefractorVelocity used to estimate the expected first break times.
+            RefractorVelocity used to estimate the expected first break times at `gather` offsets.
         first_breaks_col : str, defaults to :const:`~const.HDR_FIRST_BREAK`
             Column name from `gather.headers` where first break times are stored.
         threshold_times: float, defaults to 50
@@ -41,7 +43,7 @@ class FirstBreaksOutliers(PipelineMetric):
             Fraction of traces in the gather whose first break times differ from estimated by velocity model for more
             than `threshold_times`.
         """
-        metric = np.abs(refractor_velocity(gather.offsets) - gather[first_breaks_col].ravel()) > threshold_times
+        metric = np.abs(refractor_velocity(gather.offsets) - gather[first_breaks_col]) > threshold_times
         return np.mean(metric)
 
     @pass_calc_args

--- a/seismicpro/index.py
+++ b/seismicpro/index.py
@@ -29,7 +29,7 @@ class IndexPart(GatherContainer):
     surveys_dict : dict
         A mapping from survey names from the first level of `headers.columns` to the surveys themselves.
     indexer : BaseIndexer, optional
-        And indexer of `headers`. Created automatically if not given.
+        An indexer of `headers`. Created automatically if not given.
     copy_headers : bool, optional, defaults to False
         Whether to copy `headers` while constructing the part.
     """

--- a/seismicpro/index.py
+++ b/seismicpro/index.py
@@ -16,25 +16,33 @@ from .utils import to_list, maybe_copy
 
 class IndexPart(GatherContainer):
     """A class that represents a part of `SeismicIndex` which contains trace headers of several surveys being merged
-    together."""
+    together.
 
-    def __init__(self):
-        self._headers = None
-        self._indexer = None
-        self.common_headers = set()
-        self.surveys_dict = {}
+    Parameters
+    ----------
+    headers : pd.DataFrame
+        Trace headers of surveys in the index part. Must have `MultiIndex` columns with two levels: the first one with
+        names of surveys in the part and the second with trace headers of a particular survey.
+    common_headers : set of str
+        Trace headers with common values among all the surveys in the part (e.g. keys used to merge the surveys). Used
+        to speed up merge/apply/filter operations.
+    surveys_dict : dict
+        A mapping from survey names from the first level of `headers.columns` to the surveys themselves.
+    indexer : BaseIndexer, optional
+        And indexer of `headers`. Created automatically if not given.
+    copy_headers : bool, optional, defaults to False
+        Whether to copy `headers` while constructing the part.
+    """
 
-    def __getitem__(self, key):
-        """Select values of headers by their names."""
-        if isinstance(key, tuple):
-            key = [key]
-        return super().__getitem__(key)
-
-    def __setitem__(self, key, value):
-        """Set given values to selected headers."""
-        if isinstance(key, tuple):
-            key = [key]
-        return super().__setitem__(key, value)
+    def __init__(self, headers, common_headers, surveys_dict, indexer=None, copy_headers=False):
+        headers = headers.copy(copy_headers)
+        if indexer is None:  # Force indexer creation on headers setting
+            self.headers = headers
+        else:  # Use existing indexer to speed up part creation
+            self._headers = headers
+            self._indexer = indexer
+        self.common_headers = common_headers
+        self.surveys_dict = surveys_dict
 
     @property
     def survey_names(self):
@@ -42,30 +50,17 @@ class IndexPart(GatherContainer):
         return sorted(self.surveys_dict.keys())
 
     @classmethod
-    def from_attributes(cls, headers, surveys_dict, common_headers, copy_headers=False):
-        """Create a new index part from its attributes."""
-        part = cls()
-        part.headers = headers.copy(copy_headers)
-        part.common_headers = common_headers
-        part.surveys_dict = surveys_dict
-        return part
-
-    @classmethod
     def from_survey(cls, survey, copy_headers=False):
         """Construct an index part from a single survey."""
         if not isinstance(survey, Survey):
             raise ValueError("survey must be an instance of Survey")
 
-        headers = survey.headers.copy(copy_headers)
+        headers = survey.headers.copy(deep=False)
         common_headers = set(headers.columns)
         headers.columns = pd.MultiIndex.from_product([[survey.name], headers.columns])
 
-        part = cls()
-        part._headers = headers  # Avoid calling headers setter since the indexer is already calculated
-        part._indexer = survey._indexer  # pylint: disable=protected-access
-        part.common_headers = common_headers
-        part.surveys_dict = {survey.name: survey}
-        return part
+        # pylint: disable-next=protected-access
+        return cls(headers, common_headers, {survey.name: survey}, indexer=survey._indexer, copy_headers=copy_headers)
 
     @staticmethod
     def _filter_equal(headers, header_cols):
@@ -110,12 +105,12 @@ class IndexPart(GatherContainer):
         # Recalculate common headers in the merged DataFrame
         common_headers = on | {header for header in headers_to_check
                                       if headers[left_survey_name, header].equals(headers[right_survey_name, header])}
-        return self.from_attributes(headers, {**self.surveys_dict, **other.surveys_dict}, common_headers)
+        return type(self)(headers, common_headers, {**self.surveys_dict, **other.surveys_dict})
 
     def create_subset(self, indices):
         """Return a new `IndexPart` based on a subset of its indices given."""
         subset_headers = self.get_headers_by_indices(indices)
-        return self.from_attributes(subset_headers, self.surveys_dict, self.common_headers)
+        return type(self)(subset_headers, self.common_headers, self.surveys_dict)
 
     def copy(self, ignore=None):
         """Perform a deepcopy of all part attributes except for `surveys_dict`, `_indexer` and those specified in

--- a/seismicpro/refractor_velocity/refractor_velocity.py
+++ b/seismicpro/refractor_velocity/refractor_velocity.py
@@ -52,7 +52,7 @@ class RefractorVelocity:
 
     Now an instance of `RefractorVelocity` can be created using a `from_first_breaks` method:
     >>> offsets = gather.offsets
-    >>> fb_times = gather['FirstBreak'].ravel()
+    >>> fb_times = gather['FirstBreak']
     >>> rv = RefractorVelocity.from_first_breaks(offsets, fb_times, n_refractors=2)
 
     The same can be done by calling a `calculate_refractor_velocity` method of the gather:

--- a/seismicpro/survey/survey.py
+++ b/seismicpro/survey/survey.py
@@ -678,7 +678,7 @@ class Survey(GatherContainer, SamplesContainer):  # pylint: disable=too-many-ins
         n_quantile_traces = min(n_traces, n_quantile_traces)
 
         # Sort traces by TRACE_SEQUENCE_FILE: sequential access to trace amplitudes is much faster than random
-        traces_pos = np.sort(get_cols(headers, "TRACE_SEQUENCE_FILE").ravel() - 1)
+        traces_pos = np.sort(get_cols(headers, "TRACE_SEQUENCE_FILE") - 1)
         quantile_traces_mask = np.zeros(n_traces, dtype=np.bool_)
         quantile_traces_mask[np.random.choice(n_traces, size=n_quantile_traces, replace=False)] = True
 
@@ -786,7 +786,7 @@ class Survey(GatherContainer, SamplesContainer):  # pylint: disable=too-many-ins
 
         limits = self.limits if limits is None else self._process_limits(limits)
 
-        traces_pos = self["TRACE_SEQUENCE_FILE"].ravel() - 1
+        traces_pos = self["TRACE_SEQUENCE_FILE"] - 1
         n_samples = len(self.file_samples[limits])
 
         trace = np.empty(n_samples, dtype=self.trace_dtype)
@@ -894,7 +894,7 @@ class Survey(GatherContainer, SamplesContainer):  # pylint: disable=too-many-ins
         """
         if copy_headers:
             headers = headers.copy()
-        traces_pos = get_cols(headers, "TRACE_SEQUENCE_FILE").ravel() - 1
+        traces_pos = get_cols(headers, "TRACE_SEQUENCE_FILE") - 1
         limits = self.limits if limits is None else self._process_limits(limits)
         samples = self.file_samples[limits]
         data = self.load_traces(traces_pos, limits=limits)

--- a/seismicpro/tests/survey/test_load_gather.py
+++ b/seismicpro/tests/survey/test_load_gather.py
@@ -111,7 +111,7 @@ class TestLoad:
 
         # load_limits take priority over init_limits
         limits = init_limits if load_limits is None else load_limits
-        traces_pos = gather["TRACE_SEQUENCE_FILE"].ravel() - 1
+        traces_pos = gather["TRACE_SEQUENCE_FILE"] - 1
         gather_data = trace_data[traces_pos, limits]
 
         assert np.allclose(gather.data, gather_data)
@@ -130,7 +130,7 @@ class TestLoad:
 
         # load_limits take priority over init_limits
         limits = init_limits if load_limits is None else load_limits
-        traces_pos = gather["TRACE_SEQUENCE_FILE"].ravel() - 1
+        traces_pos = gather["TRACE_SEQUENCE_FILE"] - 1
         gather_data = trace_data[traces_pos, limits]
 
         assert np.allclose(gather.data, gather_data)

--- a/seismicpro/tests/test_gather.py
+++ b/seismicpro/tests/test_gather.py
@@ -89,11 +89,10 @@ def test_gather_getitem_headers(gather, key):
     """test_gather_getitem_headers"""
     result_getitem = gather[key]
     result_get_item = gather.get_item(key)
+    expected = gather.headers.reset_index()[key].values
 
-    expected = gather.headers[key].values
     assert np.allclose(result_getitem, result_get_item)
-    assert result_getitem.shape == (gather.shape[0], len(to_list(key)))
-    assert np.allclose(result_getitem.reshape(-1), expected.reshape(-1))
+    assert np.allclose(result_getitem, expected)
     assert result_getitem.dtype == expected.dtype
 
 

--- a/seismicpro/utils/general_utils.py
+++ b/seismicpro/utils/general_utils.py
@@ -4,6 +4,7 @@ from functools import partial
 from concurrent.futures import Future, Executor
 
 import numpy as np
+import pandas as pd
 
 
 def to_list(obj):
@@ -48,23 +49,45 @@ def get_first_defined(*args):
     return next((arg for arg in args if arg is not None), None)
 
 
-def validate_cols_exist(df, cols):
-    """Check if each column from `cols` is present either in the `df` DataFrame columns or index."""
-    df_cols = set(df.columns) | set(df.index.names)
-    missing_cols = set(to_list(cols)) - df_cols
-    if missing_cols:
-        raise KeyError(f"The following headers must be preloaded: {', '.join(missing_cols)}")
+def _process_cols(df, cols):
+    """Convert one or more column names in `df` to a list of columns depending on the column index type. Also return
+    whether a single column was passed."""
+    if df.columns.nlevels == 1:  # Flat column index
+        is_single_col = isinstance(cols, str)
+        cols = to_list(cols)
+    else:  # MultiIndex case: avoid to_list here since tuples must be preserved as is to be used for column selection
+        is_single_col = not isinstance(cols, list)
+        if is_single_col:
+            cols = [cols]
+    return cols, is_single_col
 
 
 def get_cols(df, cols):
-    """Extract columns from `cols` from the `df` DataFrame columns or index as a 2d `np.ndarray`."""
-    validate_cols_exist(df, cols)
+    """Extract columns from `cols` from the `df` DataFrame columns or index as an `np.ndarray`."""
+    cols, is_single_col = _process_cols(df, cols)
+
     # Avoid using direct pandas indexing to speed up selection of multiple columns from small DataFrames
     res = []
-    for col in to_list(cols):
-        col_values = df[col] if col in df.columns else df.index.get_level_values(col)
-        res.append(col_values.values)
+    for col in cols:
+        if col in df.columns:
+            col_values = df[col]
+        elif col in df.index.names:
+            col_values = df.index.get_level_values(col)
+        else:
+            raise KeyError(f"Unknown header {col}")
+        res.append(col_values.to_numpy())
+
+    # Single index may return multiple columns in MultiIndex case thus extra dimensionality check is required
+    if is_single_col and res[0].ndim == 1:
+        return res[0]
     return np.column_stack(res)
+
+
+def set_cols(df, cols, values):
+    """Set given `values` to selected columns of the `df` DataFrame."""
+    cols, _ = _process_cols(df, cols)
+    values = pd.DataFrame(values).to_numpy()
+    df[cols] = values
 
 
 class MissingModule:

--- a/seismicpro/utils/general_utils.py
+++ b/seismicpro/utils/general_utils.py
@@ -82,13 +82,6 @@ def get_cols(df, cols):
     return np.column_stack(res)
 
 
-def set_cols(df, cols, values):
-    """Set given `values` to selected columns of the `df` DataFrame."""
-    cols, _ = _process_cols(df, cols)
-    values = pd.DataFrame(values).to_numpy()
-    df[cols] = values
-
-
 class MissingModule:
     """Postpone raising missing module error for `module_name` until it is being actually accessed in code."""
     def __init__(self, module_name):

--- a/seismicpro/utils/general_utils.py
+++ b/seismicpro/utils/general_utils.py
@@ -77,8 +77,7 @@ def get_cols(df, cols):
             raise KeyError(f"Unknown header {col}")
         res.append(col_values.to_numpy())
 
-    # Single index may return multiple columns in MultiIndex case thus extra dimensionality check is required
-    if is_single_col and res[0].ndim == 1:
+    if is_single_col:
         return res[0]
     return np.column_stack(res)
 

--- a/seismicpro/utils/general_utils.py
+++ b/seismicpro/utils/general_utils.py
@@ -4,7 +4,6 @@ from functools import partial
 from concurrent.futures import Future, Executor
 
 import numpy as np
-import pandas as pd
 
 
 def to_list(obj):
@@ -49,9 +48,8 @@ def get_first_defined(*args):
     return next((arg for arg in args if arg is not None), None)
 
 
-def _process_cols(df, cols):
-    """Convert one or more column names in `df` to a list of columns depending on the column index type. Also return
-    whether a single column was passed."""
+def get_cols(df, cols):
+    """Extract columns from `cols` from the `df` DataFrame columns or index as an `np.ndarray`."""
     if df.columns.nlevels == 1:  # Flat column index
         is_single_col = isinstance(cols, str)
         cols = to_list(cols)
@@ -59,12 +57,6 @@ def _process_cols(df, cols):
         is_single_col = not isinstance(cols, list)
         if is_single_col:
             cols = [cols]
-    return cols, is_single_col
-
-
-def get_cols(df, cols):
-    """Extract columns from `cols` from the `df` DataFrame columns or index as an `np.ndarray`."""
-    cols, is_single_col = _process_cols(df, cols)
 
     # Avoid using direct pandas indexing to speed up selection of multiple columns from small DataFrames
     res = []


### PR DESCRIPTION
1. Now the following code
    ```python
    offset = gather["offset"]
    ```
    returns a 1d array instead of 2d. Old behavior can be obtained by always passing a list of headers similar to `pandas` convention:
    ```python
    offset_2d = gather[["offset"]]
    ```

2. Now `__setitem__` of trace containers acts identically to that of a `pd.DataFrame`. Previously the following code worked:
    ```python
    survey[["my_header"]] = np.arange(survey.n_traces)
    ```
    Now, following the `pandas` convention, it raises an error. Two valid options are:
    ```python
    survey["my_header"] = np.arange(survey.n_traces)
    survey[["my_header"]] = np.arange(survey.n_traces).reshape(-1, 1)
    ```

3. Simplifies `IndexPart` instantiation a bit.
