### PR TITLE
Store headers from gather to survey

### DIFF
--- a/seismicpro/const.py
+++ b/seismicpro/const.py
@@ -19,7 +19,7 @@ ENDIANNESS = {
 # Custom headers optionally added by SeismicPro to those from SEG-Y file
 HDR_DEAD_TRACE = 'DeadTrace'
 HDR_FIRST_BREAK = 'FirstBreak'
-HDR_TRACES_POS = 'TRACES_POS'
+HDR_TRACES_POS = 'TRACE_POS_IN_SURVEY'
 
 
 # Default velocity for spherical divergence correction as provided in Paradigm.

--- a/seismicpro/const.py
+++ b/seismicpro/const.py
@@ -19,6 +19,7 @@ ENDIANNESS = {
 # Custom headers optionally added by SeismicPro to those from SEG-Y file
 HDR_DEAD_TRACE = 'DeadTrace'
 HDR_FIRST_BREAK = 'FirstBreak'
+HDR_TRACES_POS = 'TRACES_POS'
 
 
 # Default velocity for spherical divergence correction as provided in Paradigm.

--- a/seismicpro/const.py
+++ b/seismicpro/const.py
@@ -19,7 +19,7 @@ ENDIANNESS = {
 # Custom headers optionally added by SeismicPro to those from SEG-Y file
 HDR_DEAD_TRACE = 'DeadTrace'
 HDR_FIRST_BREAK = 'FirstBreak'
-HDR_TRACES_POS = 'TRACE_POS_IN_SURVEY'
+HDR_TRACE_POS = 'TRACE_POS_IN_SURVEY'
 
 
 # Default velocity for spherical divergence correction as provided in Paradigm.

--- a/seismicpro/gather/gather.py
+++ b/seismicpro/gather/gather.py
@@ -280,11 +280,6 @@ class Gather(TraceContainer, SamplesContainer):
         -------
         self : Gather
             Gather unchanged.
-
-        Raises
-        ------
-        ValueError
-            If given `columns` are missing in `self.headers`.
         """
         columns = to_list(columns)
         _ = self[columns] # Make sure that columns are in headers

--- a/seismicpro/gather/gather.py
+++ b/seismicpro/gather/gather.py
@@ -274,7 +274,7 @@ class Gather(TraceContainer, SamplesContainer):
         Parameters
         ----------
         columns : str or list of str
-            Column names in `self.headers` that will be added to `self.survey` headers.
+            Column names from `self.headers` that will be stored to `self.survey` headers.
 
         Returns
         -------

--- a/seismicpro/gather/gather.py
+++ b/seismicpro/gather/gather.py
@@ -76,12 +76,11 @@ class Gather(TraceContainer, SamplesContainer):
     sort_by : None or str
         Headers column that was used for gather sorting. If `None`, no sorting was performed.
     """
-    def __init__(self, headers, data, samples, survey, pos):
+    def __init__(self, headers, data, samples, survey):
         self.headers = headers
         self.data = data
         self.samples = samples
         self.survey = survey
-        self.pos = pos
         self.sort_by = None
 
     @property
@@ -268,7 +267,7 @@ class Gather(TraceContainer, SamplesContainer):
             if column not in self.survey.headers.columns:
                 self.survey[column] = np.nan
             columns_pos.append(self.survey.headers.columns.get_loc(column))
-        self.survey.headers.iloc[self.pos, columns_pos] = self[columns]
+        self.survey.headers.iloc[self["TRACES_POS"], columns_pos] = self[columns]
         return self
 
     #------------------------------------------------------------------------#

--- a/seismicpro/gather/gather.py
+++ b/seismicpro/gather/gather.py
@@ -288,19 +288,16 @@ class Gather(TraceContainer, SamplesContainer):
         ValueError
             If given `columns` are missing in `self.headers`.
         """
-        headers = self.survey._headers
         columns = to_list(columns)
-        pos = self[HDR_TRACE_POS]
-        _ = headers.iloc[pos]  # iloc warmup for further setting to work much faster
-
         unknown_headers = set(columns) - set(self.headers)
         if unknown_headers:
             raise ValueError(f"Unknown headers: {', '.join(unknown_headers)}")
 
+        headers = self.survey._headers
         for column in columns:
             if column not in headers:
                 headers[column] = np.nan
-        headers.iloc[pos, headers.columns.get_indexer(columns)] = self[columns]
+            headers[column].array[self[HDR_TRACE_POS]] = self[column]
         return self
 
     #------------------------------------------------------------------------#

--- a/seismicpro/gather/gather.py
+++ b/seismicpro/gather/gather.py
@@ -293,11 +293,12 @@ class Gather(TraceContainer, SamplesContainer):
         if unknown_headers:
             raise ValueError(f"Unknown headers: {', '.join(unknown_headers)}")
 
-        headers = self.survey._headers  # pylint: disable=protected-access
+        headers = self.survey.headers
+        pos = self[HDR_TRACE_POS]
         for column in columns:
             if column not in headers:
                 headers[column] = np.nan
-            headers[column].array[self[HDR_TRACE_POS]] = self[column]
+            headers[column].array[pos] = self[column]
         return self
 
     #------------------------------------------------------------------------#

--- a/seismicpro/gather/gather.py
+++ b/seismicpro/gather/gather.py
@@ -25,7 +25,7 @@ from ..muter import Muter, MuterField
 from ..stacking_velocity import StackingVelocity, StackingVelocityField
 from ..refractor_velocity import RefractorVelocity, RefractorVelocityField
 from ..decorators import batch_method, plotter
-from ..const import HDR_FIRST_BREAK, DEFAULT_SDC_VELOCITY
+from ..const import HDR_FIRST_BREAK, HDR_TRACES_POS, DEFAULT_SDC_VELOCITY
 
 
 class Gather(TraceContainer, SamplesContainer):
@@ -269,8 +269,7 @@ class Gather(TraceContainer, SamplesContainer):
             if column not in self.survey.headers.columns:
                 self.survey[column] = np.nan
             columns_pos.append(self.survey.headers.columns.get_loc(column))
-        current_pos = self.survey._trace_indexer.get_indexer(self["TRACES_POS"])
-        self.survey.headers.iloc[current_pos, columns_pos] = self[columns]
+        self.survey.headers.iloc[self[HDR_TRACES_POS], columns_pos] = self[columns]
         return self
 
     #------------------------------------------------------------------------#

--- a/seismicpro/gather/gather.py
+++ b/seismicpro/gather/gather.py
@@ -76,11 +76,12 @@ class Gather(TraceContainer, SamplesContainer):
     sort_by : None or str
         Headers column that was used for gather sorting. If `None`, no sorting was performed.
     """
-    def __init__(self, headers, data, samples, survey):
+    def __init__(self, headers, data, samples, survey, pos):
         self.headers = headers
         self.data = data
         self.samples = samples
         self.survey = survey
+        self.pos = pos
         self.sort_by = None
 
     @property
@@ -259,6 +260,16 @@ class Gather(TraceContainer, SamplesContainer):
     def _post_filter(self, mask):
         """Remove traces from gather data that correspond to filtered headers after `Gather.filter`."""
         self.data = self.data[mask]
+
+    @batch_method(target='for')
+    def store_to_survey(self, columns):
+        columns_pos = []
+        for column in to_list(columns):
+            if column not in self.survey.headers.columns:
+                self.survey[column] = np.nan
+            columns_pos.append(self.survey.headers.columns.get_loc(column))
+        self.survey.headers.iloc[self.pos, columns_pos] = self[columns]
+        return self
 
     #------------------------------------------------------------------------#
     #                              Dump methods                              #

--- a/seismicpro/gather/gather.py
+++ b/seismicpro/gather/gather.py
@@ -293,7 +293,7 @@ class Gather(TraceContainer, SamplesContainer):
         if unknown_headers:
             raise ValueError(f"Unknown headers: {', '.join(unknown_headers)}")
 
-        headers = self.survey._headers
+        headers = self.survey._headers  # pylint: disable=protected-access
         for column in columns:
             if column not in headers:
                 headers[column] = np.nan

--- a/seismicpro/gather/gather.py
+++ b/seismicpro/gather/gather.py
@@ -282,15 +282,14 @@ class Gather(TraceContainer, SamplesContainer):
             Gather unchanged.
         """
         columns = to_list(columns)
-        _ = self[columns] # Make sure that columns are in headers
 
         headers = self.survey.headers
         pos = self[HDR_TRACE_POS]
         for column in columns:
+            column_data = self[column] # Here we also check that column is in self.headers
             if column not in headers:
                 headers[column] = np.nan
 
-            column_data = self[column]
             if not np.can_cast(column_data, headers.dtypes[column]):
                 headers[column] = headers[column].astype(column_data.dtype)
 

--- a/seismicpro/gather/gather.py
+++ b/seismicpro/gather/gather.py
@@ -263,11 +263,11 @@ class Gather(TraceContainer, SamplesContainer):
         self.data = self.data[mask]
 
     @batch_method(target='for')
-    def store_to_survey(self, columns):
+    def store_headers_to_survey(self, columns):
         columns_pos = []
         for column in to_list(columns):
-            if column not in self.survey.headers.columns:
-                self.survey[column] = np.nan
+            if column not in self.survey.headers:
+                self.survey.headers[column] = np.nan
             columns_pos.append(self.survey.headers.columns.get_loc(column))
         self.survey.headers.iloc[self[HDR_TRACES_POS], columns_pos] = self[columns]
         return self

--- a/seismicpro/gather/gather.py
+++ b/seismicpro/gather/gather.py
@@ -297,7 +297,7 @@ class Gather(TraceContainer, SamplesContainer):
 
             column_data = self[column]
             if np.issubdtype(headers[column].dtype, np.integer) and np.issubdtype(column_data.dtype, np.floating):
-                headers.astype({column: column_data.dtype})
+                headers[column] = headers[column].astype(column_data.dtype)
 
             # FIXME: Workaround for a pandas bug https://github.com/pandas-dev/pandas/issues/48998
             # iloc may call unnecessary copy of the whole column before setitem

--- a/seismicpro/gather/gather.py
+++ b/seismicpro/gather/gather.py
@@ -269,7 +269,8 @@ class Gather(TraceContainer, SamplesContainer):
             if column not in self.survey.headers.columns:
                 self.survey[column] = np.nan
             columns_pos.append(self.survey.headers.columns.get_loc(column))
-        self.survey.headers.iloc[self["TRACES_POS"], columns_pos] = self[columns]
+        current_pos = self.survey._trace_indexer.get_indexer(self["TRACES_POS"])
+        self.survey.headers.iloc[current_pos, columns_pos] = self[columns]
         return self
 
     #------------------------------------------------------------------------#

--- a/seismicpro/gather/gather.py
+++ b/seismicpro/gather/gather.py
@@ -275,7 +275,7 @@ class Gather(TraceContainer, SamplesContainer):
         Parameters
         ----------
         columns : str or list of str
-            Columns of `self.headers` to be add to `self.survey` headers.
+            Column names in `self.headers` that will be added to `self.survey` headers.
 
         Returns
         -------

--- a/seismicpro/gather/gather.py
+++ b/seismicpro/gather/gather.py
@@ -282,12 +282,12 @@ class Gather(TraceContainer, SamplesContainer):
         self : Gather
             Gather unchanged.
         """
+        columns = to_list(columns)
         columns_pos = []
-        for column in to_list(columns):
+        for column in columns:
             if column not in self.survey.headers:
                 self.survey.headers[column] = np.nan
             columns_pos.append(self.survey.headers.columns.get_loc(column))
-        columns_pos = columns_pos[0] if len(columns_pos) == 1 else columns_pos
         self.survey.headers.iloc[self[HDR_TRACE_POS], columns_pos] = self[columns]
         return self
 

--- a/seismicpro/gather/gather.py
+++ b/seismicpro/gather/gather.py
@@ -25,7 +25,7 @@ from ..muter import Muter, MuterField
 from ..stacking_velocity import StackingVelocity, StackingVelocityField
 from ..refractor_velocity import RefractorVelocity, RefractorVelocityField
 from ..decorators import batch_method, plotter
-from ..const import HDR_FIRST_BREAK, HDR_TRACES_POS, DEFAULT_SDC_VELOCITY
+from ..const import HDR_FIRST_BREAK, HDR_TRACE_POS, DEFAULT_SDC_VELOCITY
 
 
 class Gather(TraceContainer, SamplesContainer):
@@ -264,12 +264,31 @@ class Gather(TraceContainer, SamplesContainer):
 
     @batch_method(target='for')
     def store_headers_to_survey(self, columns):
+        """Save given `columns` from `self.headers` to `self.survey.headers` in the positions corresponding to traces
+        in the Gather.
+
+        Note
+        ----
+        The correct result is guaranteed only if the `self.survey` hasn't changed between gather creation and calling
+        the method.
+
+        Parameters
+        ----------
+        columns : str or list of str
+            Columns of `self.headers` to be add to `self.survey` headers.
+
+        Returns
+        -------
+        self : Gather
+            Gather unchanged.
+        """
         columns_pos = []
         for column in to_list(columns):
             if column not in self.survey.headers:
                 self.survey.headers[column] = np.nan
             columns_pos.append(self.survey.headers.columns.get_loc(column))
-        self.survey.headers.iloc[self[HDR_TRACES_POS], columns_pos] = self[columns]
+        columns_pos = columns_pos[0] if len(columns_pos) == 1 else columns_pos
+        self.survey.headers.iloc[self[HDR_TRACE_POS], columns_pos] = self[columns]
         return self
 
     #------------------------------------------------------------------------#

--- a/seismicpro/gather/gather.py
+++ b/seismicpro/gather/gather.py
@@ -265,7 +265,7 @@ class Gather(TraceContainer, SamplesContainer):
     # Target set to `for` to avoid race condition when the same trace appears in two gathers (ex. supergathers)
     @batch_method(target='for', use_lock=True)
     def store_headers_to_survey(self, columns):
-        """Save given headers from `self` to `self.survey`.
+        """Save given headers from the gather to its survey.
 
         Notes
         -----
@@ -291,7 +291,7 @@ class Gather(TraceContainer, SamplesContainer):
                 headers[column] = np.nan
 
             column_data = self[column]
-            if np.issubdtype(headers[column].dtype, np.integer) and np.issubdtype(column_data.dtype, np.floating):
+            if not np.can_cast(column_data, headers.dtypes[column]):
                 headers[column] = headers[column].astype(column_data.dtype)
 
             # FIXME: Workaround for a pandas bug https://github.com/pandas-dev/pandas/issues/48998

--- a/seismicpro/index.py
+++ b/seismicpro/index.py
@@ -57,7 +57,6 @@ class IndexPart(GatherContainer):
             raise ValueError("survey must be an instance of Survey")
 
         headers = survey.headers.copy(copy_headers)
-        headers["GLOBAL_TRACE_POS"] = np.arange(survey.n_traces)
         common_headers = set(headers.columns)
         headers.columns = pd.MultiIndex.from_product([[survey.name], headers.columns])
 
@@ -88,7 +87,7 @@ class IndexPart(GatherContainer):
 
         possibly_common_headers = self.common_headers & other.common_headers
         if on is None:
-            on = possibly_common_headers - {"TRACE_SEQUENCE_FILE", "GLOBAL_TRACE_POS"}
+            on = possibly_common_headers - {"TRACE_SEQUENCE_FILE"}
             left_df = self.headers
             right_df = other.headers
         else:
@@ -771,10 +770,9 @@ class SeismicIndex(DatasetIndex):
         index_headers = index_part.get_headers_by_indices((index,))
         empty_headers = index_headers[[]]  # Handle the case when no headers were loaded for a survey
         gather_headers = [index_headers.get(name, empty_headers) for name in survey_names]
-        traces_pos = [headers["GLOBAL_TRACE_POS"].to_numpy() for headers in gather_headers]
 
-        gathers = [survey.load_gather(pos=pos, headers=headers, limits=limits, copy_headers=copy_headers)
-                   for survey, headers, pos in zip(surveys, gather_headers, traces_pos)]
+        gathers = [survey.load_gather(headers=headers, limits=limits, copy_headers=copy_headers)
+                   for survey, headers in zip(surveys, gather_headers)]
         if is_single_survey:
             return gathers[0]
         return gathers

--- a/seismicpro/index.py
+++ b/seismicpro/index.py
@@ -12,6 +12,7 @@ from batchflow import DatasetIndex
 from .survey import Survey
 from .containers import GatherContainer
 from .utils import to_list, maybe_copy
+from .const import HDR_TRACES_POS
 
 
 class IndexPart(GatherContainer):
@@ -82,7 +83,7 @@ class IndexPart(GatherContainer):
 
         possibly_common_headers = self.common_headers & other.common_headers
         if on is None:
-            on = possibly_common_headers - {"TRACE_SEQUENCE_FILE"}
+            on = possibly_common_headers - {"TRACE_SEQUENCE_FILE", HDR_TRACES_POS}
             left_df = self.headers
             right_df = other.headers
         else:

--- a/seismicpro/index.py
+++ b/seismicpro/index.py
@@ -12,7 +12,7 @@ from batchflow import DatasetIndex
 from .survey import Survey
 from .containers import GatherContainer
 from .utils import to_list, maybe_copy
-from .const import HDR_TRACES_POS
+from .const import HDR_TRACE_POS
 
 
 class IndexPart(GatherContainer):
@@ -83,7 +83,7 @@ class IndexPart(GatherContainer):
 
         possibly_common_headers = self.common_headers & other.common_headers
         if on is None:
-            on = possibly_common_headers - {"TRACE_SEQUENCE_FILE", HDR_TRACES_POS}
+            on = possibly_common_headers - {"TRACE_SEQUENCE_FILE", HDR_TRACE_POS}
             left_df = self.headers
             right_df = other.headers
         else:

--- a/seismicpro/survey/survey.py
+++ b/seismicpro/survey/survey.py
@@ -892,7 +892,7 @@ class Survey(GatherContainer, SamplesContainer):  # pylint: disable=too-many-ins
         gather : Gather
             Loaded gather instance.
         """
-        headers =  self.headers.iloc[pos] if headers is None else headers
+        headers = self.headers.iloc[pos] if headers is None else headers
         if copy_headers:
             headers = headers.copy()
         traces_pos = get_cols(headers, "TRACE_SEQUENCE_FILE").ravel() - 1

--- a/seismicpro/survey/survey.py
+++ b/seismicpro/survey/survey.py
@@ -874,7 +874,7 @@ class Survey(GatherContainer, SamplesContainer):  # pylint: disable=too-many-ins
         # Cast the result to a C-contiguous float32 array regardless of the dtype in the source file
         return np.require(traces, dtype=np.float32, requirements="C")
 
-    def load_gather(self, headers, limits=None, copy_headers=False):
+    def load_gather(self, pos, headers=None, limits=None, copy_headers=False):
         """Load a gather with given `headers`.
 
         Parameters
@@ -892,13 +892,14 @@ class Survey(GatherContainer, SamplesContainer):  # pylint: disable=too-many-ins
         gather : Gather
             Loaded gather instance.
         """
+        headers =  self.headers.iloc[pos] if headers is None else headers
         if copy_headers:
             headers = headers.copy()
         traces_pos = get_cols(headers, "TRACE_SEQUENCE_FILE").ravel() - 1
         limits = self.limits if limits is None else self._process_limits(limits)
         samples = self.file_samples[limits]
         data = self.load_traces(traces_pos, limits=limits)
-        return Gather(headers=headers, data=data, samples=samples, survey=self)
+        return Gather(headers=headers, data=data, samples=samples, survey=self, pos=pos)
 
     def get_gather(self, index, limits=None, copy_headers=False):
         """Load a gather with given `index`.
@@ -918,7 +919,7 @@ class Survey(GatherContainer, SamplesContainer):  # pylint: disable=too-many-ins
         gather : Gather
             Loaded gather instance.
         """
-        return self.load_gather(self.get_headers_by_indices((index,)), limits=limits, copy_headers=copy_headers)
+        return self.load_gather(pos=self.get_traces_locs((index,)), limits=limits, copy_headers=copy_headers)
 
     def sample_gather(self, limits=None, copy_headers=False):
         """Load a gather with random index.

--- a/seismicpro/survey/survey.py
+++ b/seismicpro/survey/survey.py
@@ -23,7 +23,7 @@ from ..gather import Gather
 from ..metrics import PartialMetric
 from ..containers import GatherContainer, SamplesContainer
 from ..utils import to_list, maybe_copy, get_cols
-from ..const import ENDIANNESS, HDR_DEAD_TRACE, HDR_FIRST_BREAK
+from ..const import ENDIANNESS, HDR_DEAD_TRACE, HDR_FIRST_BREAK, HDR_TRACES_POS
 
 
 class Survey(GatherContainer, SamplesContainer):  # pylint: disable=too-many-instance-attributes
@@ -312,16 +312,10 @@ class Survey(GatherContainer, SamplesContainer):  # pylint: disable=too-many-ins
         """bool: `mark_dead_traces` called."""
         return self.n_dead_traces is not None
 
-    @property
-    def headers(self):
-        """pd.DataFrame: loaded trace headers."""
-        return super().headers
-
-    @headers.setter
+    @GatherContainer.headers.setter
     def headers(self, headers):
         super(Survey, self.__class__).headers.fset(self, headers)
-        self._headers["TRACES_POS"] = np.arange(self.n_traces)
-        self._trace_indexer = pd.Index(self["TRACES_POS"])
+        self._headers[HDR_TRACES_POS] = np.arange(self.n_traces)
 
     def __del__(self):
         """Close SEG-Y file handler on survey destruction."""

--- a/seismicpro/survey/survey.py
+++ b/seismicpro/survey/survey.py
@@ -224,6 +224,7 @@ class Survey(GatherContainer, SamplesContainer):  # pylint: disable=too-many-ins
         # Set loaded survey headers and construct its fast indexer
         self._headers = None
         self._indexer = None
+        self._trace_indexer = None
         self.headers = headers
 
         # Validate trace headers for consistency
@@ -320,6 +321,7 @@ class Survey(GatherContainer, SamplesContainer):  # pylint: disable=too-many-ins
     def headers(self, headers):
         super(Survey, self.__class__).headers.fset(self, headers)
         self._headers["TRACES_POS"] = np.arange(self.n_traces)
+        self._trace_indexer = pd.Index(self["TRACES_POS"])
 
     def __del__(self):
         """Close SEG-Y file handler on survey destruction."""

--- a/seismicpro/survey/survey.py
+++ b/seismicpro/survey/survey.py
@@ -311,6 +311,16 @@ class Survey(GatherContainer, SamplesContainer):  # pylint: disable=too-many-ins
         """bool: `mark_dead_traces` called."""
         return self.n_dead_traces is not None
 
+    @property
+    def headers(self):
+        """pd.DataFrame: loaded trace headers."""
+        return super().headers
+
+    @headers.setter
+    def headers(self, headers):
+        super(Survey, self.__class__).headers.fset(self, headers)
+        self._headers["TRACES_POS"] = np.arange(self.n_traces)
+
     def __del__(self):
         """Close SEG-Y file handler on survey destruction."""
         self.segy_handler.close()
@@ -874,7 +884,7 @@ class Survey(GatherContainer, SamplesContainer):  # pylint: disable=too-many-ins
         # Cast the result to a C-contiguous float32 array regardless of the dtype in the source file
         return np.require(traces, dtype=np.float32, requirements="C")
 
-    def load_gather(self, pos, headers=None, limits=None, copy_headers=False):
+    def load_gather(self, headers, limits=None, copy_headers=False):
         """Load a gather with given `headers`.
 
         Parameters
@@ -892,14 +902,13 @@ class Survey(GatherContainer, SamplesContainer):  # pylint: disable=too-many-ins
         gather : Gather
             Loaded gather instance.
         """
-        headers = self.headers.iloc[pos] if headers is None else headers
         if copy_headers:
             headers = headers.copy()
         traces_pos = get_cols(headers, "TRACE_SEQUENCE_FILE").ravel() - 1
         limits = self.limits if limits is None else self._process_limits(limits)
         samples = self.file_samples[limits]
         data = self.load_traces(traces_pos, limits=limits)
-        return Gather(headers=headers, data=data, samples=samples, survey=self, pos=pos)
+        return Gather(headers=headers, data=data, samples=samples, survey=self)
 
     def get_gather(self, index, limits=None, copy_headers=False):
         """Load a gather with given `index`.
@@ -919,7 +928,7 @@ class Survey(GatherContainer, SamplesContainer):  # pylint: disable=too-many-ins
         gather : Gather
             Loaded gather instance.
         """
-        return self.load_gather(pos=self.get_traces_locs((index,)), limits=limits, copy_headers=copy_headers)
+        return self.load_gather(self.get_headers_by_indices((index,)), limits=limits, copy_headers=copy_headers)
 
     def sample_gather(self, limits=None, copy_headers=False):
         """Load a gather with random index.

--- a/seismicpro/survey/survey.py
+++ b/seismicpro/survey/survey.py
@@ -23,7 +23,7 @@ from ..gather import Gather
 from ..metrics import PartialMetric
 from ..containers import GatherContainer, SamplesContainer
 from ..utils import to_list, maybe_copy, get_cols
-from ..const import ENDIANNESS, HDR_DEAD_TRACE, HDR_FIRST_BREAK, HDR_TRACES_POS
+from ..const import ENDIANNESS, HDR_DEAD_TRACE, HDR_FIRST_BREAK, HDR_TRACE_POS
 
 
 class Survey(GatherContainer, SamplesContainer):  # pylint: disable=too-many-instance-attributes
@@ -313,8 +313,10 @@ class Survey(GatherContainer, SamplesContainer):  # pylint: disable=too-many-ins
 
     @GatherContainer.headers.setter
     def headers(self, headers):
+        """Reconstruct trace positions on each headers assignment."""
         GatherContainer.headers.fset(self, headers)
-        self.headers[HDR_TRACES_POS] = np.arange(self.n_traces, dtype=np.int32)
+        htp_dtype = np.int32 if len(headers) < np.iinfo(np.int32).max else np.int64
+        self.headers[HDR_TRACE_POS] = np.arange(self.n_traces, dtype=htp_dtype)
 
     def __del__(self):
         """Close SEG-Y file handler on survey destruction."""

--- a/seismicpro/survey/survey.py
+++ b/seismicpro/survey/survey.py
@@ -224,7 +224,6 @@ class Survey(GatherContainer, SamplesContainer):  # pylint: disable=too-many-ins
         # Set loaded survey headers and construct its fast indexer
         self._headers = None
         self._indexer = None
-        self._trace_indexer = None
         self.headers = headers
 
         # Validate trace headers for consistency
@@ -314,8 +313,8 @@ class Survey(GatherContainer, SamplesContainer):  # pylint: disable=too-many-ins
 
     @GatherContainer.headers.setter
     def headers(self, headers):
-        super(Survey, self.__class__).headers.fset(self, headers)
-        self._headers[HDR_TRACES_POS] = np.arange(self.n_traces)
+        GatherContainer.headers.fset(self, headers)
+        self.headers[HDR_TRACES_POS] = np.arange(self.n_traces, dtype=np.int32)
 
     def __del__(self):
         """Close SEG-Y file handler on survey destruction."""

--- a/seismicpro/tests/survey/asserters.py
+++ b/seismicpro/tests/survey/asserters.py
@@ -42,6 +42,8 @@ def assert_survey_loaded(survey, segy_path, expected_name, expected_index, expec
     assert set(survey.headers.index.names) == expected_index
     assert set(survey.headers.index.names) | set(survey.headers.columns) == expected_headers
     assert survey.headers.index.is_monotonic_increasing
+    # Check that HDR_TRACE_POS reflects traces positions in the headers. We are checking `survey.headers` instead of
+    # `loaded_headers`, because `loaded_headers` are sorted differently, and HEAT_TRACE_POS has lost all meaning there.
     assert np.array_equal(survey.headers[HDR_TRACE_POS].values, np.arange(n_traces))
     # Restore the order of the traces from the source file
     loaded_headers = survey.headers.reset_index().sort_values(by="TRACE_SEQUENCE_FILE")

--- a/seismicpro/tests/survey/asserters.py
+++ b/seismicpro/tests/survey/asserters.py
@@ -7,6 +7,7 @@ import segyio
 import numpy as np
 
 from seismicpro.utils.indexer import create_indexer
+from seismicpro.const import HDR_TRACE_POS
 
 from ..utils import assert_indexers_equal
 
@@ -14,6 +15,9 @@ from ..utils import assert_indexers_equal
 # Define default tolerances to check if two float values are close
 RTOL = 1e-5
 ATOL = 1e-7
+
+# Define external headers that are not involved in testing process
+EXTERNAL_HEADERS = {HDR_TRACE_POS}
 
 
 def assert_survey_loaded(survey, segy_path, expected_name, expected_index, expected_headers, rtol=RTOL, atol=ATOL):
@@ -39,7 +43,7 @@ def assert_survey_loaded(survey, segy_path, expected_name, expected_index, expec
     assert survey.n_traces == n_traces
     assert len(survey.headers) == n_traces
     assert set(survey.headers.index.names) == expected_index
-    assert set(survey.headers.index.names) | set(survey.headers.columns) == expected_headers
+    assert (set(survey.headers.index.names) | set(survey.headers.columns)) - EXTERNAL_HEADERS == expected_headers
     assert survey.headers.index.is_monotonic_increasing
 
     # Restore the order of the traces from the source file
@@ -47,7 +51,7 @@ def assert_survey_loaded(survey, segy_path, expected_name, expected_index, expec
 
     # Check loaded trace headers values
     assert np.array_equal(loaded_headers["TRACE_SEQUENCE_FILE"].values, np.arange(1, n_traces + 1))
-    for header in set(loaded_headers.columns) - {"TRACE_SEQUENCE_FILE"}:
+    for header in set(loaded_headers.columns) - {"TRACE_SEQUENCE_FILE", *EXTERNAL_HEADERS}:
         assert np.array_equal(loaded_headers[header].values,
                               survey.segy_handler.attributes(segyio.tracefield.keys[header])[:])
 

--- a/seismicpro/tests/survey/conftest.py
+++ b/seismicpro/tests/survey/conftest.py
@@ -9,7 +9,7 @@ from seismicpro import Survey
 @pytest.fixture(params=["TRACE_SEQUENCE_FILE", ("FieldRecord",), ["INLINE_3D", "CROSSLINE_3D"]])
 def survey_no_stats(segy_path, request):
     """Return surveys with no stats collected."""
-    return Survey(segy_path, header_index=request.param, header_cols="all", n_workers=1, bar=False)
+    return Survey(segy_path, header_index=request.param, header_cols="all", n_workers=1, bar=False, validate=False)
 
 
 @pytest.fixture

--- a/seismicpro/tests/survey/test_reindex.py
+++ b/seismicpro/tests/survey/test_reindex.py
@@ -43,9 +43,8 @@ class TestReindex:
         4. Values of trace headers has not changed, only their order in `survey.headers`.
         """
         survey_copy = survey.copy()
-        survey_headers = (set(survey.headers.index.names) | set(survey.headers.columns)) - {HDR_TRACE_POS}
+        survey_headers = set(survey.headers.index.names) | set(survey.headers.columns)
         survey_reindexed = survey.reindex(new_index, inplace=inplace)
-        survey_reindexed.headers.drop(columns=HDR_TRACE_POS, errors="ignore", inplace=True)
 
         if isinstance(new_index, str):
             new_index = [new_index]
@@ -55,7 +54,7 @@ class TestReindex:
 
         # Check that only order of rows in headers has changed
         merged_headers = pd.merge(survey_copy.headers.reset_index(), survey_reindexed.headers.reset_index(),
-                                  on=list(survey_headers))
+                                  on=list(survey_headers - {HDR_TRACE_POS}))
         assert len(merged_headers) == len(survey_copy.headers)
 
         # Check that all other attributes has not changed

--- a/seismicpro/tests/survey/test_reindex.py
+++ b/seismicpro/tests/survey/test_reindex.py
@@ -3,8 +3,8 @@
 import pytest
 import pandas as pd
 
+from seismicpro.const import HDR_TRACE_POS
 from . import assert_surveys_equal, assert_survey_processed_inplace
-from .asserters import EXTERNAL_HEADERS
 
 
 class TestReindex:
@@ -43,11 +43,10 @@ class TestReindex:
         4. Values of trace headers has not changed, only their order in `survey.headers`.
         """
         survey_copy = survey.copy()
-        survey_headers = (set(survey.headers.index.names) | set(survey.headers.columns)) - EXTERNAL_HEADERS
+        survey_headers = (set(survey.headers.index.names) | set(survey.headers.columns)) - {HDR_TRACE_POS}
         survey_reindexed = survey.reindex(new_index, inplace=inplace)
 
-        for header in EXTERNAL_HEADERS:
-            survey_reindexed.headers.drop(columns=header, errors="ignore", inplace=True)
+        survey_reindexed.headers.drop(columns=HDR_TRACE_POS, errors="ignore", inplace=True)
 
         if isinstance(new_index, str):
             new_index = [new_index]

--- a/seismicpro/tests/survey/test_reindex.py
+++ b/seismicpro/tests/survey/test_reindex.py
@@ -4,6 +4,7 @@ import pytest
 import pandas as pd
 
 from . import assert_surveys_equal, assert_survey_processed_inplace
+from .asserters import EXTERNAL_HEADERS
 
 
 class TestReindex:
@@ -42,8 +43,11 @@ class TestReindex:
         4. Values of trace headers has not changed, only their order in `survey.headers`.
         """
         survey_copy = survey.copy()
-        survey_headers = set(survey.headers.index.names) | set(survey.headers.columns)
+        survey_headers = (set(survey.headers.index.names) | set(survey.headers.columns)) - EXTERNAL_HEADERS
         survey_reindexed = survey.reindex(new_index, inplace=inplace)
+
+        for header in EXTERNAL_HEADERS:
+            survey_reindexed.headers.drop(columns=header, errors="ignore", inplace=True)
 
         if isinstance(new_index, str):
             new_index = [new_index]

--- a/seismicpro/tests/survey/test_reindex.py
+++ b/seismicpro/tests/survey/test_reindex.py
@@ -45,7 +45,6 @@ class TestReindex:
         survey_copy = survey.copy()
         survey_headers = (set(survey.headers.index.names) | set(survey.headers.columns)) - {HDR_TRACE_POS}
         survey_reindexed = survey.reindex(new_index, inplace=inplace)
-
         survey_reindexed.headers.drop(columns=HDR_TRACE_POS, errors="ignore", inplace=True)
 
         if isinstance(new_index, str):

--- a/seismicpro/tests/test_batch.py
+++ b/seismicpro/tests/test_batch.py
@@ -11,7 +11,7 @@ from seismicpro import Survey, SeismicDataset
 @pytest.fixture
 def dataset(segy_path):
     """dataset"""
-    survey = Survey(segy_path, header_index='FieldRecord', name='raw')
+    survey = Survey(segy_path, header_index='FieldRecord', name='raw', validate=False)
     return SeismicDataset(survey)
 
 def test_batch_load(dataset):
@@ -21,7 +21,7 @@ def test_batch_load(dataset):
 
 def test_batch_load_combined(segy_path):
     """test_batch_load_combined"""
-    survey = Survey(segy_path, header_index='TRACE_SEQUENCE_FILE', name='raw')
+    survey = Survey(segy_path, header_index='TRACE_SEQUENCE_FILE', name='raw', validate=False)
     dataset = SeismicDataset(survey)
     batch = dataset.next_batch(200)
     batch = batch.load(src='raw', combined=True)

--- a/seismicpro/tests/test_dump_merge.py
+++ b/seismicpro/tests/test_dump_merge.py
@@ -20,26 +20,27 @@ from .survey.asserters import EXTERNAL_HEADERS
 @pytest.mark.parametrize('dump_index', [1, 3])
 def test_dump_single_gather(segy_path, tmp_path, name, retain_parent_segy_headers, header_index, header_cols,
                             dump_index):
-    survey = Survey(segy_path, header_index=header_index, header_cols=header_cols, name=name)
+    survey = Survey(segy_path, header_index=header_index, header_cols=header_cols, name=name, validate=False)
     expected_gather = survey.get_gather(dump_index)
     expected_gather.dump(path=tmp_path, name=name, retain_parent_segy_headers=retain_parent_segy_headers)
 
     files = glob.glob(os.path.join(tmp_path, '*'))
     assert len(files) == 1, "Dump creates more than one file"
 
-    dumped_survey = Survey(files[0], header_index=header_index, header_cols=header_cols)
+    dumped_survey = Survey(files[0], header_index=header_index, header_cols=header_cols, validate=False)
     ix = 1 if header_index == 'TRACE_SEQUENCE_FILE' else dump_index
     dumped_gather = dumped_survey.get_gather(index=ix)
-    drop_columns = ["TRACE_SEQUENCE_FILE"] + list({"TRACE_SAMPLE_INTERVAL"}
-                                                  & set(tuple(expected_gather.headers.columns)))
+    drop_columns = ["TRACE_SEQUENCE_FILE", *EXTERNAL_HEADERS]
+    drop_columns += ["TRACE_SAMPLE_INTERVAL"] if "TRACE_SAMPLE_INTERVAL" in expected_gather.headers.columns else []
+
     compare_gathers(expected_gather, dumped_gather, drop_cols=drop_columns, check_types=True,
                     same_survey=False)
 
     if retain_parent_segy_headers:
-        expected_survey = Survey(segy_path, header_index=header_index, header_cols='all')
+        expected_survey = Survey(segy_path, header_index=header_index, header_cols='all', validate=False)
         full_exp_headers = expected_survey.headers
         full_exp_headers = full_exp_headers.loc[dump_index:dump_index].reset_index()
-        full_dump_headers = Survey(files[0], header_index=header_index, header_cols='all').headers
+        full_dump_headers = Survey(files[0], header_index=header_index, header_cols='all', validate=False).headers
         full_dump_headers = full_dump_headers.reset_index()
         sample_rates = full_dump_headers['TRACE_SAMPLE_INTERVAL']
         assert np.unique(sample_rates) > 1
@@ -54,7 +55,7 @@ def test_dump_single_gather(segy_path, tmp_path, name, retain_parent_segy_header
                          ((dict(path=''), FileNotFoundError),
                           (dict(path='somepath', name=''), ValueError)))
 def test_dump_single_gather_with_invalid_kwargs(segy_path, dump_kwargs, error):
-    survey = Survey(segy_path, header_index='FieldRecord')
+    survey = Survey(segy_path, header_index='FieldRecord', validate=False)
     gather = survey.get_gather(1)
     with pytest.raises(error):
         gather.dump(**dump_kwargs)
@@ -63,7 +64,7 @@ def test_dump_single_gather_with_invalid_kwargs(segy_path, dump_kwargs, error):
 @pytest.mark.parametrize('mode', ['one_folder', 'split'])
 @pytest.mark.parametrize('indices', [[1], [1, 3], 'all'])
 def test_aggregate_segys(segy_path, tmp_path, mode, indices):
-    expected_survey = Survey(segy_path, header_index='FieldRecord', header_cols='all', name='raw')
+    expected_survey = Survey(segy_path, header_index='FieldRecord', header_cols='all', name='raw', validate=False)
     indices = expected_survey.headers.index.drop_duplicates() if indices == 'all' else indices
 
     if mode == 'split':
@@ -76,15 +77,16 @@ def test_aggregate_segys(segy_path, tmp_path, mode, indices):
 
     aggregate_segys(os.path.join(tmp_path, './**/*.sgy'), os.path.join(tmp_path, 'aggr.sgy'), recursive=True)
 
-    dumped_survey = Survey(os.path.join(tmp_path, 'aggr.sgy'), header_index='FieldRecord', header_cols='all')
+    dumped_survey = Survey(os.path.join(tmp_path, 'aggr.sgy'), header_index='FieldRecord', header_cols='all',
+                           validate=False)
     assert np.allclose(expected_survey.samples, dumped_survey.samples),"Samples don't match"
     assert np.allclose(expected_survey.sample_rate, dumped_survey.sample_rate), "Sample rate doesn't match"
     assert np.allclose(expected_survey.n_samples, dumped_survey.n_samples), "length of samples doesn't match"
 
     #TODO: optimize
-    drop_columns = ["TRACE_SEQUENCE_FILE"] + list({"TRACE_SAMPLE_INTERVAL"}
-                                                  & set(tuple(expected_survey.headers.columns))
-                                                  | EXTERNAL_HEADERS)
+    drop_columns = ["TRACE_SEQUENCE_FILE", *EXTERNAL_HEADERS]
+    drop_columns += ["TRACE_SAMPLE_INTERVAL"] if "TRACE_SAMPLE_INTERVAL" in expected_survey.headers.columns else []
+
     expected_survey_headers = (expected_survey.headers.loc[indices].reset_index()
                                                                    .sort_values(['FieldRecord', 'TraceNumber'])
                                                                    .drop(columns=drop_columns)

--- a/seismicpro/tests/test_dump_merge.py
+++ b/seismicpro/tests/test_dump_merge.py
@@ -9,8 +9,9 @@ import pytest
 import numpy as np
 
 from seismicpro import Survey, aggregate_segys
+from seismicpro.const import HDR_TRACE_POS
 from .test_gather import compare_gathers
-from .survey.asserters import EXTERNAL_HEADERS
+
 
 
 @pytest.mark.parametrize('name', ['some_name', None])
@@ -30,7 +31,7 @@ def test_dump_single_gather(segy_path, tmp_path, name, retain_parent_segy_header
     dumped_survey = Survey(files[0], header_index=header_index, header_cols=header_cols, validate=False)
     ix = 1 if header_index == 'TRACE_SEQUENCE_FILE' else dump_index
     dumped_gather = dumped_survey.get_gather(index=ix)
-    drop_columns = ["TRACE_SEQUENCE_FILE", *EXTERNAL_HEADERS]
+    drop_columns = ["TRACE_SEQUENCE_FILE", HDR_TRACE_POS]
     drop_columns += ["TRACE_SAMPLE_INTERVAL"] if "TRACE_SAMPLE_INTERVAL" in expected_gather.headers.columns else []
 
     compare_gathers(expected_gather, dumped_gather, drop_cols=drop_columns, check_types=True,
@@ -45,7 +46,7 @@ def test_dump_single_gather(segy_path, tmp_path, name, retain_parent_segy_header
         sample_rates = full_dump_headers['TRACE_SAMPLE_INTERVAL']
         assert np.unique(sample_rates) > 1
         assert np.allclose(sample_rates[0] / 1000, expected_survey.sample_rate)
-        drop_cols = ["TRACE_SEQUENCE_FILE", "TRACE_SAMPLE_INTERVAL", *list(EXTERNAL_HEADERS)]
+        drop_cols = ["TRACE_SEQUENCE_FILE", "TRACE_SAMPLE_INTERVAL", HDR_TRACE_POS]
         full_exp_headers.drop(columns=drop_cols, inplace=True)
         full_dump_headers.drop(columns=drop_cols, inplace=True)
         assert full_exp_headers.equals(full_dump_headers)
@@ -84,7 +85,7 @@ def test_aggregate_segys(segy_path, tmp_path, mode, indices):
     assert np.allclose(expected_survey.n_samples, dumped_survey.n_samples), "length of samples doesn't match"
 
     #TODO: optimize
-    drop_columns = ["TRACE_SEQUENCE_FILE", *EXTERNAL_HEADERS]
+    drop_columns = ["TRACE_SEQUENCE_FILE", HDR_TRACE_POS]
     drop_columns += ["TRACE_SAMPLE_INTERVAL"] if "TRACE_SAMPLE_INTERVAL" in expected_survey.headers.columns else []
 
     expected_survey_headers = (expected_survey.headers.loc[indices].reset_index()

--- a/seismicpro/tests/test_dump_merge.py
+++ b/seismicpro/tests/test_dump_merge.py
@@ -13,7 +13,6 @@ from seismicpro.const import HDR_TRACE_POS
 from .test_gather import compare_gathers
 
 
-
 @pytest.mark.parametrize('name', ['some_name', None])
 @pytest.mark.parametrize('retain_parent_segy_headers', [False, True])
 @pytest.mark.parametrize('header_index', ['FieldRecord', 'TRACE_SEQUENCE_FILE'])
@@ -87,7 +86,6 @@ def test_aggregate_segys(segy_path, tmp_path, mode, indices):
     #TODO: optimize
     drop_columns = ["TRACE_SEQUENCE_FILE", HDR_TRACE_POS]
     drop_columns += ["TRACE_SAMPLE_INTERVAL"] if "TRACE_SAMPLE_INTERVAL" in expected_survey.headers.columns else []
-
     expected_survey_headers = (expected_survey.headers.loc[indices].reset_index()
                                                                    .sort_values(['FieldRecord', 'TraceNumber'])
                                                                    .drop(columns=drop_columns)

--- a/seismicpro/tests/test_gather.py
+++ b/seismicpro/tests/test_gather.py
@@ -35,8 +35,12 @@ def gather(survey):
 
 
 @pytest.fixture(scope='function')
-def gather_with_cols(survey):
-    """gather_with_cols"""
+def gather_with_cols(segy_path):
+    """Fixture uses only for methods that affect created survey, thus we recreating survey every function call."""
+    survey = Survey(segy_path, header_index=['INLINE_3D', 'CROSSLINE_3D'],
+                    header_cols=['offset', 'FieldRecord'], validate=False)
+    survey.remove_dead_traces(bar=False)
+
     gather = survey.get_gather((0, 0))
     gather.headers["col_1"] = np.arange(gather.n_traces, dtype=np.int32)
     gather.headers["col_2"] = 100 * np.random.random(gather.n_traces)

--- a/seismicpro/tests/test_gather.py
+++ b/seismicpro/tests/test_gather.py
@@ -197,6 +197,15 @@ def test_gather_copy(gather, ignore):
     compare_gathers(copy_gather, gather, check_types=True)
 
 
+def test_gather_store_headers_to_survey(gather):
+    """test_gather_store_headers_to_survey"""
+    gather.store_headers_to_survey("offset")
+
+def test_gather_store_headers_to_survey_new_header(gather):
+    """test_gather_store_headers_to_survey_new_header"""
+    gather["new_header"] = 18
+    gather.store_headers_to_survey("new_header")
+
 @pytest.mark.parametrize('tracewise, use_global', [[True, False], [False, False], [False, True]])
 @pytest.mark.parametrize('q', [0.1, [0.1, 0.2], (0.1, 0.2), np.array([0.1, 0.2])])
 def test_gather_get_quantile(gather, tracewise, use_global, q):

--- a/seismicpro/tests/test_gather.py
+++ b/seismicpro/tests/test_gather.py
@@ -203,7 +203,7 @@ def test_gather_store_headers_to_survey(gather, columns):
 
 def test_gather_store_headers_to_survey_new_header(gather):
     """test_gather_store_headers_to_survey_new_header"""
-    gather["new_header"] = 18
+    gather.headers["new_header"] = 18
     gather.store_headers_to_survey("new_header")
 
 @pytest.mark.parametrize('tracewise, use_global', [[True, False], [False, False], [False, True]])

--- a/seismicpro/tests/test_gather.py
+++ b/seismicpro/tests/test_gather.py
@@ -57,7 +57,6 @@ def compare_gathers(first, second, drop_cols=None, check_types=False, same_surve
 
     first_headers = first.headers.reset_index()
     second_headers = second.headers.reset_index()
-
     if drop_cols is not None:
         first_headers.drop(columns=drop_cols, errors="ignore", inplace=True)
         second_headers.drop(columns=drop_cols, errors="ignore", inplace=True)
@@ -220,7 +219,6 @@ def test_gather_store_headers_to_survey(gather_with_cols, columns):
     headers_from_survey = survey.headers.loc[gather_with_cols.index].sort_values(by="offset")
     headers_from_gather = gather_with_cols.headers.sort_values(by="offset")
     assert np.allclose(headers_from_survey[columns], headers_from_gather[columns])
-
 
 @pytest.mark.parametrize('tracewise, use_global', [[True, False], [False, False], [False, True]])
 @pytest.mark.parametrize('q', [0.1, [0.1, 0.2], (0.1, 0.2), np.array([0.1, 0.2])])

--- a/seismicpro/tests/test_gather.py
+++ b/seismicpro/tests/test_gather.py
@@ -196,10 +196,10 @@ def test_gather_copy(gather, ignore):
 
     compare_gathers(copy_gather, gather, check_types=True)
 
-
-def test_gather_store_headers_to_survey(gather):
+@pytest.mark.parametrize('columns', ['offset', ['offset'], ['offset', 'FieldRecord']])
+def test_gather_store_headers_to_survey(gather, columns):
     """test_gather_store_headers_to_survey"""
-    gather.store_headers_to_survey("offset")
+    gather.store_headers_to_survey(columns)
 
 def test_gather_store_headers_to_survey_new_header(gather):
     """test_gather_store_headers_to_survey_new_header"""

--- a/seismicpro/tests/test_gather.py
+++ b/seismicpro/tests/test_gather.py
@@ -9,6 +9,7 @@ import numpy as np
 from seismicpro import Survey, Muter, StackingVelocity
 from seismicpro.utils import to_list
 from seismicpro.const import HDR_FIRST_BREAK
+from .survey.asserters import EXTERNAL_HEADERS
 
 
 # Constants
@@ -43,9 +44,10 @@ def compare_gathers(first, second, drop_cols=None, check_types=False, same_surve
 
     first_headers = first.headers.reset_index()
     second_headers = second.headers.reset_index()
-    if drop_cols:
-        first_headers.drop(columns=drop_cols, errors="ignore", inplace=True)
-        second_headers.drop(columns=drop_cols, errors="ignore", inplace=True)
+
+    drop_cols = to_list(drop_cols) + to_list(EXTERNAL_HEADERS) if drop_cols is not None else EXTERNAL_HEADERS
+    first_headers.drop(columns=drop_cols, errors="ignore", inplace=True)
+    second_headers.drop(columns=drop_cols, errors="ignore", inplace=True)
 
     assert len(first_headers) == len(second_headers)
     if len(first_headers) > 0:

--- a/seismicpro/tests/test_gather.py
+++ b/seismicpro/tests/test_gather.py
@@ -9,7 +9,6 @@ import numpy as np
 from seismicpro import Survey, Muter, StackingVelocity
 from seismicpro.utils import to_list
 from seismicpro.const import HDR_FIRST_BREAK
-from .survey.asserters import EXTERNAL_HEADERS
 
 
 # Constants
@@ -22,7 +21,7 @@ NUMPY_ATTRS = ['data', 'samples']
 def survey(segy_path):
     """Create gather"""
     survey = Survey(segy_path, header_index=['INLINE_3D', 'CROSSLINE_3D'],
-                    header_cols=['offset', 'FieldRecord'])
+                    header_cols=['offset', 'FieldRecord'], validate=False)
     survey.remove_dead_traces(bar=False)
     survey.collect_stats(bar=False)
     survey.headers[HDR_FIRST_BREAK] = np.random.randint(0, 1000, len(survey.headers))
@@ -55,9 +54,9 @@ def compare_gathers(first, second, drop_cols=None, check_types=False, same_surve
     first_headers = first.headers.reset_index()
     second_headers = second.headers.reset_index()
 
-    drop_cols = (to_list(drop_cols) + to_list(EXTERNAL_HEADERS)) if drop_cols is not None else EXTERNAL_HEADERS
-    first_headers.drop(columns=drop_cols, errors="ignore", inplace=True)
-    second_headers.drop(columns=drop_cols, errors="ignore", inplace=True)
+    if drop_cols is not None:
+        first_headers.drop(columns=drop_cols, errors="ignore", inplace=True)
+        second_headers.drop(columns=drop_cols, errors="ignore", inplace=True)
 
     assert len(first_headers) == len(second_headers)
     if len(first_headers) > 0:
@@ -275,7 +274,8 @@ def test_gather_stacking_velocity(gather):
 
 def test_gather_get_central_gather(segy_path):
     """test_gather_get_central_gather"""
-    survey = Survey(segy_path, header_index=['INLINE_3D', 'CROSSLINE_3D'], header_cols=['offset', 'FieldRecord'])
+    survey = Survey(segy_path, header_index=['INLINE_3D', 'CROSSLINE_3D'], header_cols=['offset', 'FieldRecord'],
+                    validate=False)
     survey = survey.generate_supergathers()
     gather = survey.sample_gather()
     gather.get_central_gather()

--- a/seismicpro/tests/test_gather.py
+++ b/seismicpro/tests/test_gather.py
@@ -41,6 +41,7 @@ def gather_with_cols(survey):
     gather = survey.get_gather((0, 0))
     gather.headers["col_1"] = np.arange(gather.n_traces, dtype=np.int32)
     gather.headers["col_2"] = 100 * np.random.random(gather.n_traces)
+    gather.headers["offset"] = gather["offset"] * 0.1
     return gather
 
 
@@ -208,7 +209,7 @@ def test_gather_copy(gather, ignore):
     compare_gathers(copy_gather, gather, check_types=True)
 
 
-@pytest.mark.parametrize('columns', ['offset', 'col_1', ['col_1'], ['col_1', 'col_2']])
+@pytest.mark.parametrize('columns', ['offset', 'FieldRecord', 'col_1', ['col_1'], ['col_1', 'col_2']])
 def test_gather_store_headers_to_survey(gather_with_cols, columns):
     """test_gather_store_headers_to_survey"""
     gather_with_cols.store_headers_to_survey(columns)

--- a/seismicpro/tests/test_index_dataset.py
+++ b/seismicpro/tests/test_index_dataset.py
@@ -15,62 +15,64 @@ class TestInit:
 
     def test_from_survey(self, segy_path, header_index):
         """Test instantiation from a single survey."""
-        survey = Survey(segy_path, header_index=header_index)
+        survey = Survey(segy_path, header_index=header_index, validate=False)
         _ = SeismicIndex(survey)
 
     def test_from_index(self, segy_path, header_index):
         """Test instantiation from an already created index."""
-        survey = Survey(segy_path, header_index=header_index)
+        survey = Survey(segy_path, header_index=header_index, validate=False)
         index = SeismicIndex(survey)
         _ = SeismicIndex(index)
 
     def test_concat(self, segy_path, header_index):
         """Test concatenation of two surveys."""
-        sur1 = Survey(segy_path, header_index=header_index, name="sur")
-        sur2 = Survey(segy_path, header_index=header_index, name="sur")
+        sur1 = Survey(segy_path, header_index=header_index, name="sur", validate=False)
+        sur2 = Survey(segy_path, header_index=header_index, name="sur", validate=False)
         _ = SeismicIndex(sur1, sur2, mode="c")
 
     def test_concat_wrong_names_fails(self, segy_path, header_index):
         """Concat must fail if surveys have different names."""
-        sur1 = Survey(segy_path, header_index=header_index, name="sur")
-        sur2 = Survey(segy_path, header_index=header_index, name="not_sur")
+        sur1 = Survey(segy_path, header_index=header_index, name="sur", validate=False)
+        sur2 = Survey(segy_path, header_index=header_index, name="not_sur", validate=False)
         with pytest.raises(ValueError):
             _ = SeismicIndex(sur1, sur2, mode="c")
 
     def test_concat_wrong_index_fails(self, segy_path, header_index):
         """Concat must fail if surveys are indexed by different headers."""
-        sur1 = Survey(segy_path, header_index=header_index, name="sur")
-        sur2 = Survey(segy_path, header_index="CDP", name="sur")
+        sur1 = Survey(segy_path, header_index=header_index, name="sur", validate=False)
+        sur2 = Survey(segy_path, header_index="CDP", name="sur", validate=False)
         with pytest.raises(ValueError):
             _ = SeismicIndex(sur1, sur2, mode="c")
 
     def test_merge(self, segy_path, header_index):
         """Test merging of two surveys."""
-        sur1 = Survey(segy_path, header_index=header_index, header_cols=HEADER_COLS, name="before")
-        sur2 = Survey(segy_path, header_index=header_index, header_cols=HEADER_COLS, name="after")
+        sur1 = Survey(segy_path, header_index=header_index, header_cols=HEADER_COLS, name="before", validate=False)
+        sur2 = Survey(segy_path, header_index=header_index, header_cols=HEADER_COLS, name="after", validate=False)
         _ = SeismicIndex(sur1, sur2, mode="m")
 
     def test_merge_wrong_names_fails(self, segy_path, header_index):
         """Merge must fail if surveys have same names."""
-        sur1 = Survey(segy_path, header_index=header_index, header_cols=HEADER_COLS, name="sur")
-        sur2 = Survey(segy_path, header_index=header_index, header_cols=HEADER_COLS, name="sur")
+        sur1 = Survey(segy_path, header_index=header_index, header_cols=HEADER_COLS, name="sur", validate=False)
+        sur2 = Survey(segy_path, header_index=header_index, header_cols=HEADER_COLS, name="sur", validate=False)
         with pytest.raises(ValueError):
             _ = SeismicIndex(sur1, sur2, mode="m")
 
     def test_merge_wrong_index_fails(self, segy_path, header_index):
         """Merge must fail if surveys are indexed by different headers."""
-        sur1 = Survey(segy_path, header_index=header_index, header_cols=HEADER_COLS, name="before")
-        sur2 = Survey(segy_path, header_index="CDP", header_cols=HEADER_COLS, name="after")
+        sur1 = Survey(segy_path, header_index=header_index, header_cols=HEADER_COLS, name="before", validate=False)
+        sur2 = Survey(segy_path, header_index="CDP", header_cols=HEADER_COLS, name="after", validate=False)
         with pytest.raises(ValueError):
             _ = SeismicIndex(sur1, sur2, mode="m")
 
     def test_merge_concat(self, segy_path, header_index):
         """Test merge followed by concat."""
-        s1_before = Survey(segy_path, header_index=header_index, header_cols=HEADER_COLS, name="before")
-        s2_before = Survey(segy_path, header_index=header_index, header_cols=HEADER_COLS, name="before")
+        s1_before = Survey(segy_path, header_index=header_index, header_cols=HEADER_COLS, name="before",
+                           validate=False)
+        s2_before = Survey(segy_path, header_index=header_index, header_cols=HEADER_COLS, name="before",
+                           validate=False)
 
-        s1_after = Survey(segy_path, header_index=header_index, header_cols=HEADER_COLS, name="after")
-        s2_after = Survey(segy_path, header_index=header_index, header_cols=HEADER_COLS, name="after")
+        s1_after = Survey(segy_path, header_index=header_index, header_cols=HEADER_COLS, name="after", validate=False)
+        s2_after = Survey(segy_path, header_index=header_index, header_cols=HEADER_COLS, name="after", validate=False)
 
         index_s1 = SeismicIndex(s1_before, s1_after, mode="m")
         index_s2 = SeismicIndex(s2_before, s2_after, mode="m")
@@ -78,11 +80,13 @@ class TestInit:
 
     def test_concat_merge(self, segy_path, header_index):
         """Test concat followed by merge."""
-        s1_before = Survey(segy_path, header_index=header_index, header_cols=HEADER_COLS, name="before")
-        s2_before = Survey(segy_path, header_index=header_index, header_cols=HEADER_COLS, name="before")
+        s1_before = Survey(segy_path, header_index=header_index, header_cols=HEADER_COLS, name="before",
+                           validate=False)
+        s2_before = Survey(segy_path, header_index=header_index, header_cols=HEADER_COLS, name="before",
+                           validate=False)
 
-        s1_after = Survey(segy_path, header_index=header_index, header_cols=HEADER_COLS, name="after")
-        s2_after = Survey(segy_path, header_index=header_index, header_cols=HEADER_COLS, name="after")
+        s1_after = Survey(segy_path, header_index=header_index, header_cols=HEADER_COLS, name="after", validate=False)
+        s2_after = Survey(segy_path, header_index=header_index, header_cols=HEADER_COLS, name="after", validate=False)
 
         index_before = SeismicIndex(s1_before, s2_before, mode="c")
         index_after = SeismicIndex(s1_after, s2_after, mode="c")
@@ -93,7 +97,7 @@ class TestInit:
 @pytest.mark.parametrize("test_class", [SeismicIndex, SeismicDataset])
 def test_index_split(test_class, segy_path, header_index):
     """Test whether index or dataset `split` runs."""
-    survey = Survey(segy_path, header_index=header_index, bar=False)
+    survey = Survey(segy_path, header_index=header_index, bar=False, validate=False)
     test_obj = test_class(survey)
     test_obj.split()
 
@@ -102,7 +106,7 @@ def test_index_split(test_class, segy_path, header_index):
 @pytest.mark.parametrize("test_class", [SeismicIndex, SeismicDataset])
 def test_index_collect_stats(test_class, segy_path, header_index):
     """Test whether index or dataset `collect_stats` runs."""
-    survey = Survey(segy_path, header_index=header_index, bar=False)
+    survey = Survey(segy_path, header_index=header_index, bar=False, validate=False)
     test_obj = test_class(survey)
     test_obj.collect_stats()
 
@@ -111,7 +115,7 @@ def test_index_collect_stats(test_class, segy_path, header_index):
 @pytest.mark.parametrize("test_class", [SeismicIndex, SeismicDataset])
 def test_index_split_collect_stats(test_class, segy_path, header_index):
     """Test whether `collect_stats` runs for a subset of index or dataset."""
-    survey = Survey(segy_path, header_index=header_index, bar=False)
+    survey = Survey(segy_path, header_index=header_index, bar=False, validate=False)
     test_obj = test_class(survey)
     test_obj.split(0.5)
     test_obj.train.collect_stats()

--- a/seismicpro/tests/test_segy_generator.py
+++ b/seismicpro/tests/test_segy_generator.py
@@ -35,5 +35,5 @@ def segy_path(request):
 def test_generated_segy_loading(segy_path, header_index):
     s = Survey(segy_path, header_index=header_index, header_cols=['FieldRecord', 'TraceNumber', 'SourceX', 'SourceY',
                                                                   'GroupX', 'GroupY', 'offset', 'CDP_X', 'CDP_Y',
-                                                                  'INLINE_3D', 'CROSSLINE_3D'])
+                                                                  'INLINE_3D', 'CROSSLINE_3D'], validate=False)
     assert s.sample_gather()


### PR DESCRIPTION
New features:
* A new method to `Gather`. This method provided an abilibty to save any columns from `Gather` to the parent `Survey`. 
* Tests for this method.
* Add `validate=False` for all tests where new Survey was created to avoid a bunch or useless warnings and speed up testing process.
* Add validate as a parameter to Survey testing
* Fix other tests that failed thanks to new method


Used in pipeline, method `store_headers_to_survey` (any suggestions about naming are highly welcome) will save columns to `Survey` that generated certain `Gather` object.   