### PR TITLE
Fix refine

### DIFF
--- a/seismicpro/containers.py
+++ b/seismicpro/containers.py
@@ -288,6 +288,11 @@ class GatherContainer(TraceContainer):
         """int: The number of gathers."""
         return len(self.indices)
 
+    @property
+    def is_empty(self):
+        """bool: Whether no gathers are stored in the container."""
+        return self.n_gathers == 0
+
     def get_traces_locs(self, indices):
         """Get positions of traces in `headers` by `indices` of their gathers.
 

--- a/seismicpro/field.py
+++ b/seismicpro/field.py
@@ -36,7 +36,7 @@ from inspect import getmembers
 from functools import cached_property
 
 import numpy as np
-from sklearn.neighbors import NearestNeighbors
+from scipy.spatial import KDTree
 
 from .utils import to_list, read_vfunc, dump_vfunc, Coordinates
 from .utils.interpolation import IDWInterpolator, DelaunayInterpolator, CloughTocherInterpolator, RBFInterpolator
@@ -118,7 +118,7 @@ class Field:
         items."""
         if self.n_items < 2:
             return 0
-        return NearestNeighbors(n_neighbors=2, n_jobs=-1).fit(self.coords).kneighbors()[0][:, 1].mean()
+        return KDTree(self.coords).query(self.coords, k=[2], workers=-1)[0].mean()
 
     @property
     def default_neighborhood_radius(self):

--- a/seismicpro/utils/interpolation/spatial.py
+++ b/seismicpro/utils/interpolation/spatial.py
@@ -26,7 +26,7 @@ import cv2
 import numpy as np
 from scipy import interpolate
 from scipy.spatial import KDTree
-from scipy.spatial.qhull import Delaunay, QhullError
+from scipy.spatial.qhull import Delaunay, QhullError  # pylint: disable=no-name-in-module
 
 
 def parse_inputs(coords, values=None):

--- a/seismicpro/utils/interpolation/spatial.py
+++ b/seismicpro/utils/interpolation/spatial.py
@@ -211,7 +211,7 @@ class IDWInterpolator(ValuesAgnosticInterpolator):
         super().__init__(coords, values)
         if neighbors is None:
             neighbors = len(self.coords)
-        self.neighbors = np.arange(min(neighbors, len(self.coords))) + 1  # Indices of neighbors to get
+        self.neighbors = np.arange(min(neighbors, len(self.coords))) + 1  # One-based indices of neighbors to get
         self.radius = radius
         self.use_radius = radius is not None
         self.nearest_neighbors = KDTree(self.coords)
@@ -247,6 +247,8 @@ class IDWInterpolator(ValuesAgnosticInterpolator):
         return weights
 
     def _aggregate_values(self, indices, weights):
+        """Average values with given `indices` with corresponding `weights`. Both `indices` and `weights` are 2d
+        `np.ndarray`s with shape (n_items, n_indices)."""
         return (self.values[indices] * weights[:, :, None]).sum(axis=1).astype(self.values.dtype)
 
     def _get_reference_indices_neighbors(self, coords):


### PR DESCRIPTION
* Change `_get_refined_values` logic:
  * Now only ignored values are interpolated,
  * Now `create_interpolator` passes all interpolator `kwargs` for refinement.
* Speed up `RefractorVelocityField.from_survey` by ~2x for surveys with a large number of small (~100 traces) gathers (e.g. indexed by (`INLINE_3D`, `CROSSLINE_3D`))
* Switch from `NearestNeighbors` to `KDTree` in a couple of places to speed things up