### PR TITLE
Sort gather by multiple headers

### DIFF
--- a/seismicpro/gather/gather.py
+++ b/seismicpro/gather/gather.py
@@ -1516,8 +1516,8 @@ class Gather(TraceContainer, SamplesContainer):
         if tick_src == "time":
             major_labels =  self.samples
         if tick_src == "samples":
-            major_labels = np.arange(self.n_samples
-)
+            major_labels = np.arange(self.n_samples)
+
         set_ticks(ax, 'y', major_labels=major_labels, **{"label": tick_src, **ticker})
 
     def plot_nmo_correction(self, min_vel=1500, max_vel=6000, figsize=(6, 4.5), show_grid=True, **kwargs):

--- a/seismicpro/gather/gather.py
+++ b/seismicpro/gather/gather.py
@@ -1520,7 +1520,7 @@ class Gather(TraceContainer, SamplesContainer):
         UNITS = {  # pylint: disable=invalid-name
             "offset": ", m",
         }
-        
+
         tick_src = [ix_tick_src + UNITS.get(ix_tick_src, '') for ix_tick_src in tick_src]
 
         set_ticks(ax, 'x', major_labels=major_labels, minor_labels=minor_labels, **{"label": tick_src, **ticker})

--- a/seismicpro/gather/gather.py
+++ b/seismicpro/gather/gather.py
@@ -191,7 +191,7 @@ class Gather(TraceContainer, SamplesContainer):
         new_self.samples = self.samples[indices[1]]
 
         # Check that `sort_by` still represents the actual trace sorting as it might be changed during getitem.
-        if new_self.sort_by is not None: 
+        if new_self.sort_by is not None:
             if (np.lexsort(new_self.headers[to_list(new_self.sort_by)].values.T[::-1]) != np.arange(len(data))).any():
                 new_self.sort_by = None
         return new_self
@@ -903,22 +903,17 @@ class Gather(TraceContainer, SamplesContainer):
 
     @batch_method(target="for")
     def sort(self, by):
-        """Sort gather `headers` and traces by specified headers.
+        """Sort gather by specified headers.
 
         Parameters
         ----------
         by : str or iterable of str
-            `headers` column names to sort the gather by.
+            Headers names to sort the gather by.
 
         Returns
         -------
         self : Gather
-            Gather sorted by `by` headers. Sets `sort_by` attribute to `by`.
-
-        Raises
-        ------
-        ValueError
-            If `by` header was not loaded.
+            Gather sorted by given headers. Sets `sort_by` attribute to `by`.
         """
         if self.sort_by == by:
             return self

--- a/seismicpro/gather/gather.py
+++ b/seismicpro/gather/gather.py
@@ -1308,7 +1308,6 @@ class Gather(TraceContainer, SamplesContainer):
         ValueError
             If given `mode` is unknown.
             If `colorbar` is not `bool` or `dict`.
-            If length of `color` doesn't match the number of traces in gather.
             If `event_headers` argument has the wrong format or given outlier processing mode is unknown.
             If `x_ticker` or `y_ticker` has the wrong format.
         """
@@ -1502,22 +1501,22 @@ class Gather(TraceContainer, SamplesContainer):
         return top_ax
 
     def _set_x_ticks(self, ax, tick_src, ticker):
-        tick_src = to_list(tick_src or self.sort_by or 'index')[:2]
+        """Infer and set ticks for x axis. """
+        tick_src = to_list(tick_src or self.sort_by or 'Index')[:2]
         if tick_src[0] == "index":
             major_labels, minor_labels = np.arange(self.n_traces), None
         elif len(tick_src) == 1:
             major_labels, minor_labels =  self[tick_src[0]], None
         else:
             major_labels, minor_labels = self[tick_src].T
-
         set_ticks(ax, 'x', major_labels=major_labels, minor_labels=minor_labels, **{"label": tick_src, **ticker})
 
     def _set_y_ticks(self, ax, tick_src, ticker):
+        """Infer and set ticks for y axis. """
         if tick_src == "time":
             major_labels =  self.samples
         if tick_src == "samples":
             major_labels = np.arange(self.n_samples)
-
         set_ticks(ax, 'y', major_labels=major_labels, **{"label": tick_src, **ticker})
 
     def plot_nmo_correction(self, min_vel=1500, max_vel=6000, figsize=(6, 4.5), show_grid=True, **kwargs):

--- a/seismicpro/gather/gather.py
+++ b/seismicpro/gather/gather.py
@@ -1528,7 +1528,8 @@ class Gather(TraceContainer, SamplesContainer):
     def _set_y_ticks(self, ax, tick_src, ticker):
         """Infer and set ticks for y axis. """
         tick_src = tick_src.title()
-        if tick_src == "Time, ms":
+        if tick_src == "Time":
+            tick_src = "Time, ms"
             major_labels =  self.samples
         if tick_src == "Samples":
             major_labels = np.arange(self.n_samples)

--- a/seismicpro/gather/gather.py
+++ b/seismicpro/gather/gather.py
@@ -1522,8 +1522,9 @@ class Gather(TraceContainer, SamplesContainer):
         }
 
         tick_src = [ix_tick_src + UNITS.get(ix_tick_src, '') for ix_tick_src in tick_src]
+        axis_label = '\n'.join(tick_src)
 
-        set_ticks(ax, 'x', major_labels=major_labels, minor_labels=minor_labels, **{"label": tick_src, **ticker})
+        set_ticks(ax, 'x', major_labels=major_labels, minor_labels=minor_labels, **{"label": axis_label, **ticker})
 
     def _set_y_ticks(self, ax, tick_src, ticker):
         """Infer and set ticks for y axis. """

--- a/seismicpro/gather/gather.py
+++ b/seismicpro/gather/gather.py
@@ -1325,10 +1325,15 @@ class Gather(TraceContainer, SamplesContainer):
         plotters_dict[mode](ax, title=title, x_ticker=x_ticker, y_ticker=y_ticker, **kwargs)
         return self
 
-    def _plot_histogram(self, ax, title, x_ticker, y_ticker, x_tick_src="Amplitude", bins=None,
+    def _plot_histogram(self, ax, title, x_ticker, y_ticker, x_tick_src="amplitude", bins=None,
                         log=False, grid=True, **kwargs):
         """Plot histogram of the data specified by x_tick_src."""
-        data = self.data.ravel() if x_tick_src == "Amplitude" else self[x_tick_src]
+        if x_tick_src.title() == 'Amplitude':
+            x_tick_src = 'Amplitude'
+            data = self.data.ravel()
+        else:
+            data = self[x_tick_src]
+
         _ = ax.hist(data, bins=bins, **kwargs)
         set_ticks(ax, "x", **{"label": x_tick_src, 'round_to': None, **x_ticker})
         set_ticks(ax, "y", **{"label": "Counts", **y_ticker})
@@ -1339,7 +1344,7 @@ class Gather(TraceContainer, SamplesContainer):
         ax.set_title(**{'label': None, **title})
 
     # pylint: disable=too-many-arguments
-    def _plot_seismogram(self, ax, title, x_ticker, y_ticker, x_tick_src=None, y_tick_src='Time', colorbar=False,
+    def _plot_seismogram(self, ax, title, x_ticker, y_ticker, x_tick_src=None, y_tick_src='time', colorbar=False,
                          q_vmin=0.1, q_vmax=0.9, event_headers=None, top_header=None, **kwargs):
         """Plot the gather as a 2d grayscale image of seismic traces."""
         # Make the axis divisible to further plot colorbar and header subplot
@@ -1351,7 +1356,7 @@ class Gather(TraceContainer, SamplesContainer):
         self._finalize_plot(ax, title, divider, event_headers, top_header, x_ticker, y_ticker, x_tick_src, y_tick_src)
 
     #pylint: disable=invalid-name
-    def _plot_wiggle(self, ax, title, x_ticker, y_ticker, x_tick_src=None, y_tick_src="Time", norm_tracewise=True,
+    def _plot_wiggle(self, ax, title, x_ticker, y_ticker, x_tick_src=None, y_tick_src="time", norm_tracewise=True,
                      std=0.5, event_headers=None, top_header=None, lw=None, alpha=None, color="black", **kwargs):
         """Plot the gather as an amplitude vs time plot for each trace."""
         # Make the axis divisible to further plot colorbar and header subplot
@@ -1502,8 +1507,9 @@ class Gather(TraceContainer, SamplesContainer):
 
     def _set_x_ticks(self, ax, tick_src, ticker):
         """Infer and set ticks for x axis. """
-        tick_src = to_list(tick_src or self.sort_by or 'Index')[:2]
-        if tick_src[0] == "Index":
+        tick_src = to_list(tick_src or self.sort_by or 'index')[:2]
+        if tick_src[0].title() == "Index":
+            tick_src[0] = "Index"
             major_labels, minor_labels = np.arange(self.n_traces), None
         elif len(tick_src) == 1:
             major_labels, minor_labels =  self[tick_src[0]], None
@@ -1514,6 +1520,7 @@ class Gather(TraceContainer, SamplesContainer):
 
     def _set_y_ticks(self, ax, tick_src, ticker):
         """Infer and set ticks for y axis. """
+        tick_src = tick_src.title()
         if tick_src == "Time":
             major_labels =  self.samples
         if tick_src == "Samples":

--- a/seismicpro/gather/gather.py
+++ b/seismicpro/gather/gather.py
@@ -1520,7 +1520,7 @@ class Gather(TraceContainer, SamplesContainer):
             tick_labels = self._get_y_ticks(tick_src)
         else:
             raise ValueError(f"Unknown axis {axis}")
-        set_ticks(ax, axis, tick_labels=tick_labels, **{"labels": tick_src, **ticker})
+        set_ticks(ax, axis, tick_labels=tick_labels, **{"label": tick_src, **ticker})
 
     def plot_nmo_correction(self, min_vel=1500, max_vel=6000, figsize=(6, 4.5), show_grid=True, **kwargs):
         """Perform interactive NMO correction of the gather with selected constant velocity.

--- a/seismicpro/gather/gather.py
+++ b/seismicpro/gather/gather.py
@@ -1265,13 +1265,13 @@ class Gather(TraceContainer, SamplesContainer):
         ax : matplotlib.axes.Axes, optional, defaults to None
             An axis of the figure to plot on. If not given, it will be created automatically.
         x_tick_src : str, optional
-            Source of the tick labels to be plotted on x axis. For "seismogram" and "wiggle" can be either "index"
+            Source of the tick labels to be plotted on x axis. For "seismogram" and "wiggle" can be either "Index"
             (default if gather is not sorted) or any header; for "hist" it also defines the data source and can be
-            either "amplitude" (default) or any header.
+            either "Amplitude" (default) or any header.
             Also serves as a default for axis label.
         y_tick_src : str, optional
-            Source of the tick labels to be plotted on y axis. For "seismogram" and "wiggle" can be either "time"
-            (default) or "samples"; has no effect in "hist" mode. Also serves as a default for axis label.
+            Source of the tick labels to be plotted on y axis. For "seismogram" and "wiggle" can be either "Time"
+            (default) or "Samples"; has no effect in "hist" mode. Also serves as a default for axis label.
         event_headers : str, array-like or dict, optional, defaults to None
             Valid only for "seismogram" and "wiggle" modes.
             Headers, whose values will be displayed over the gather plot. Must be measured in milliseconds.
@@ -1325,13 +1325,13 @@ class Gather(TraceContainer, SamplesContainer):
         plotters_dict[mode](ax, title=title, x_ticker=x_ticker, y_ticker=y_ticker, **kwargs)
         return self
 
-    def _plot_histogram(self, ax, title, x_ticker, y_ticker, x_tick_src="amplitude", bins=None,
+    def _plot_histogram(self, ax, title, x_ticker, y_ticker, x_tick_src="Amplitude", bins=None,
                         log=False, grid=True, **kwargs):
         """Plot histogram of the data specified by x_tick_src."""
-        data = self.data.ravel() if x_tick_src == "amplitude" else self[x_tick_src]
+        data = self.data.ravel() if x_tick_src == "Amplitude" else self[x_tick_src]
         _ = ax.hist(data, bins=bins, **kwargs)
-        set_ticks(ax, "x", major_labels=None, **{"label": x_tick_src, 'round_to': None, **x_ticker})
-        set_ticks(ax, "y", major_labels=None, **{"label": "counts", **y_ticker})
+        set_ticks(ax, "x", **{"label": x_tick_src, 'round_to': None, **x_ticker})
+        set_ticks(ax, "y", **{"label": "Counts", **y_ticker})
 
         ax.grid(grid)
         if log:
@@ -1339,7 +1339,7 @@ class Gather(TraceContainer, SamplesContainer):
         ax.set_title(**{'label': None, **title})
 
     # pylint: disable=too-many-arguments
-    def _plot_seismogram(self, ax, title, x_ticker, y_ticker, x_tick_src=None, y_tick_src='time', colorbar=False,
+    def _plot_seismogram(self, ax, title, x_ticker, y_ticker, x_tick_src=None, y_tick_src='Time', colorbar=False,
                          q_vmin=0.1, q_vmax=0.9, event_headers=None, top_header=None, **kwargs):
         """Plot the gather as a 2d grayscale image of seismic traces."""
         # Make the axis divisible to further plot colorbar and header subplot
@@ -1503,20 +1503,22 @@ class Gather(TraceContainer, SamplesContainer):
     def _set_x_ticks(self, ax, tick_src, ticker):
         """Infer and set ticks for x axis. """
         tick_src = to_list(tick_src or self.sort_by or 'Index')[:2]
-        if tick_src[0] == "index":
+        if tick_src[0] == "Index":
             major_labels, minor_labels = np.arange(self.n_traces), None
         elif len(tick_src) == 1:
             major_labels, minor_labels =  self[tick_src[0]], None
         else:
-            major_labels, minor_labels = self[tick_src].T
+            major_labels, minor_labels = self[tick_src[0]], self[tick_src[1]]
+
         set_ticks(ax, 'x', major_labels=major_labels, minor_labels=minor_labels, **{"label": tick_src, **ticker})
 
     def _set_y_ticks(self, ax, tick_src, ticker):
         """Infer and set ticks for y axis. """
-        if tick_src == "time":
+        if tick_src == "Time":
             major_labels =  self.samples
-        if tick_src == "samples":
+        if tick_src == "Samples":
             major_labels = np.arange(self.n_samples)
+    
         set_ticks(ax, 'y', major_labels=major_labels, **{"label": tick_src, **ticker})
 
     def plot_nmo_correction(self, min_vel=1500, max_vel=6000, figsize=(6, 4.5), show_grid=True, **kwargs):

--- a/seismicpro/gather/gather.py
+++ b/seismicpro/gather/gather.py
@@ -902,30 +902,26 @@ class Gather(TraceContainer, SamplesContainer):
 
     @batch_method(target="for")
     def sort(self, by):
-        """Sort gather `headers` and traces by specified header column.
+        """Sort gather `headers` and traces by specified headers.
 
         Parameters
         ----------
-        by : str
-            `headers` column name to sort the gather by.
+        by : str or iterable of str
+            `headers` column names to sort the gather by.
 
         Returns
         -------
         self : Gather
-            Gather sorted by `by` column. Sets `sort_by` attribute to `by`.
+            Gather sorted by `by` headers. Sets `sort_by` attribute to `by`.
 
         Raises
         ------
-        TypeError
-            If `by` is not str.
         ValueError
-            If `by` column was not loaded in `headers`.
+            If `by` header was not loaded.
         """
-        if not isinstance(by, str):
-            raise TypeError(f'`by` should be str, not {type(by)}')
         if self.sort_by == by:
             return self
-        order = np.argsort(self[by], kind='stable')
+        order = np.lexsort(np.transpose(self[to_list(by)])[::-1])
         self.sort_by = by
         self.data = self.data[order]
         self.headers = self.headers.iloc[order]
@@ -1528,7 +1524,7 @@ class Gather(TraceContainer, SamplesContainer):
             tick_labels = self._get_y_ticks(tick_src)
         else:
             raise ValueError(f"Unknown axis {axis}")
-        set_ticks(ax, axis, tick_labels=tick_labels, **{"label": tick_src, **ticker})
+        set_ticks(ax, axis, tick_labels=tick_labels, **{"labels": tick_src, **ticker})
 
     def plot_nmo_correction(self, min_vel=1500, max_vel=6000, figsize=(6, 4.5), show_grid=True, **kwargs):
         """Perform interactive NMO correction of the gather with selected constant velocity.

--- a/seismicpro/gather/gather.py
+++ b/seismicpro/gather/gather.py
@@ -189,7 +189,7 @@ class Gather(TraceContainer, SamplesContainer):
         # The two-element `indices` tuple describes indices of traces and samples to be obtained respectively
         new_self.headers = self.headers.iloc[indices[0]]
         new_self.samples = self.samples[indices[1]]
-        
+
         # If the gather was sorted, verify that getitem does not break sorting
         if new_self.sort_by is not None:
             if isinstance(indices[0], slice):
@@ -1518,7 +1518,7 @@ class Gather(TraceContainer, SamplesContainer):
             major_labels =  self.samples
         if tick_src == "Samples":
             major_labels = np.arange(self.n_samples)
-    
+
         set_ticks(ax, 'y', major_labels=major_labels, **{"label": tick_src, **ticker})
 
     def plot_nmo_correction(self, min_vel=1500, max_vel=6000, figsize=(6, 4.5), show_grid=True, **kwargs):

--- a/seismicpro/gather/gather.py
+++ b/seismicpro/gather/gather.py
@@ -191,8 +191,9 @@ class Gather(TraceContainer, SamplesContainer):
         new_self.samples = self.samples[indices[1]]
 
         # Check that `sort_by` still represents the actual trace sorting as it might be changed during getitem.
-        if new_self.sort_by is not None and not new_self.headers[new_self.sort_by].is_monotonic_increasing:
-            new_self.sort_by = None
+        if new_self.sort_by is not None: 
+            if (np.lexsort(new_self.headers[to_list(new_self.sort_by)].values.T[::-1]) != np.arange(len(data))).any():
+                new_self.sort_by = None
         return new_self
 
     def __str__(self):
@@ -921,7 +922,7 @@ class Gather(TraceContainer, SamplesContainer):
         """
         if self.sort_by == by:
             return self
-        order = np.lexsort(np.transpose(self[to_list(by)])[::-1])
+        order = np.lexsort(self[to_list(by)].T[::-1])
         self.sort_by = by
         self.data = self.data[order]
         self.headers = self.headers.iloc[order]

--- a/seismicpro/gather/gather.py
+++ b/seismicpro/gather/gather.py
@@ -1351,7 +1351,7 @@ class Gather(TraceContainer, SamplesContainer):
         self._finalize_plot(ax, title, divider, event_headers, top_header, x_ticker, y_ticker, x_tick_src, y_tick_src)
 
     #pylint: disable=invalid-name
-    def _plot_wiggle(self, ax, title, x_ticker, y_ticker, x_tick_src=None, y_tick_src="time", norm_tracewise=True,
+    def _plot_wiggle(self, ax, title, x_ticker, y_ticker, x_tick_src=None, y_tick_src="Time", norm_tracewise=True,
                      std=0.5, event_headers=None, top_header=None, lw=None, alpha=None, color="black", **kwargs):
         """Plot the gather as an amplitude vs time plot for each trace."""
         # Make the axis divisible to further plot colorbar and header subplot

--- a/seismicpro/gather/gather.py
+++ b/seismicpro/gather/gather.py
@@ -918,8 +918,7 @@ class Gather(TraceContainer, SamplesContainer):
             Gather sorted by given headers. Sets `sort_by` attribute to `by`.
         """
         by = to_list(by)
-        sort_by = to_list(self.sort_by)
-        if len(sort_by) >= len(by) and all(i == j for i, j in zip(sort_by, by)):
+        if by == to_list(self.sort_by)[:len(by)]:
             return self
 
         order = np.lexsort(self[by[::-1]].T)

--- a/seismicpro/gather/gather.py
+++ b/seismicpro/gather/gather.py
@@ -1271,7 +1271,7 @@ class Gather(TraceContainer, SamplesContainer):
             Also serves as a default for axis label.
         y_tick_src : str, optional
             Source of the tick labels to be plotted on y axis. For "seismogram" and "wiggle" can be either "time"
-            (default) or "Samples"; has no effect in "hist" mode. Also serves as a default for axis label.
+            (default) or "samples"; has no effect in "hist" mode. Also serves as a default for axis label.
         event_headers : str, array-like or dict, optional, defaults to None
             Valid only for "seismogram" and "wiggle" modes.
             Headers, whose values will be displayed over the gather plot. Must be measured in milliseconds.

--- a/seismicpro/gather/gather.py
+++ b/seismicpro/gather/gather.py
@@ -1265,12 +1265,12 @@ class Gather(TraceContainer, SamplesContainer):
         ax : matplotlib.axes.Axes, optional, defaults to None
             An axis of the figure to plot on. If not given, it will be created automatically.
         x_tick_src : str, optional
-            Source of the tick labels to be plotted on x axis. For "seismogram" and "wiggle" can be either "Index"
+            Source of the tick labels to be plotted on x axis. For "seismogram" and "wiggle" can be either "index"
             (default if gather is not sorted) or any header; for "hist" it also defines the data source and can be
-            either "Amplitude" (default) or any header.
+            either "amplitude" (default) or any header.
             Also serves as a default for axis label.
         y_tick_src : str, optional
-            Source of the tick labels to be plotted on y axis. For "seismogram" and "wiggle" can be either "Time"
+            Source of the tick labels to be plotted on y axis. For "seismogram" and "wiggle" can be either "time"
             (default) or "Samples"; has no effect in "hist" mode. Also serves as a default for axis label.
         event_headers : str, array-like or dict, optional, defaults to None
             Valid only for "seismogram" and "wiggle" modes.
@@ -1516,12 +1516,19 @@ class Gather(TraceContainer, SamplesContainer):
         else:
             major_labels, minor_labels = self[tick_src[0]], self[tick_src[1]]
 
+        # Format axis label
+        UNITS = {  # pylint: disable=invalid-name
+            "offset": ", m",
+        }
+        
+        tick_src = [ix_tick_src + UNITS.get(ix_tick_src, '') for ix_tick_src in tick_src]
+
         set_ticks(ax, 'x', major_labels=major_labels, minor_labels=minor_labels, **{"label": tick_src, **ticker})
 
     def _set_y_ticks(self, ax, tick_src, ticker):
         """Infer and set ticks for y axis. """
         tick_src = tick_src.title()
-        if tick_src == "Time":
+        if tick_src == "Time, ms":
             major_labels =  self.samples
         if tick_src == "Samples":
             major_labels = np.arange(self.n_samples)

--- a/seismicpro/refractor_velocity/refractor_velocity.py
+++ b/seismicpro/refractor_velocity/refractor_velocity.py
@@ -703,8 +703,8 @@ class RefractorVelocity:
                                                                                **kwargs)
         if kwargs:
             raise ValueError(f"kwargs contains unknown keys {kwargs.keys()}")
-        set_ticks(ax, "x", tick_labels=None, label="offset, m", **x_ticker)
-        set_ticks(ax, "y", tick_labels=None, label="time, ms", **y_ticker)
+        set_ticks(ax, "x", "offset", **x_ticker)
+        set_ticks(ax, "y", "Time", **y_ticker)
 
         max_offset = get_first_defined(max_offset, self.max_offset, self.piecewise_offsets[-1])
         ax.scatter(self.offsets, self.times, s=1, color="black", label="first breaks")

--- a/seismicpro/refractor_velocity/refractor_velocity.py
+++ b/seismicpro/refractor_velocity/refractor_velocity.py
@@ -703,8 +703,8 @@ class RefractorVelocity:
                                                                                **kwargs)
         if kwargs:
             raise ValueError(f"kwargs contains unknown keys {kwargs.keys()}")
-        set_ticks(ax, "x", "offset", **x_ticker)
-        set_ticks(ax, "y", "Time", **y_ticker)
+        set_ticks(ax, "x", "offset, m", **x_ticker)
+        set_ticks(ax, "y", "Time, ms", **y_ticker)
 
         max_offset = get_first_defined(max_offset, self.max_offset, self.piecewise_offsets[-1])
         ax.scatter(self.offsets, self.times, s=1, color="black", label="first breaks")

--- a/seismicpro/semblance/semblance.py
+++ b/seismicpro/semblance/semblance.py
@@ -329,7 +329,7 @@ class Semblance(BaseSemblance):
             stacking_velocities_ix = ((stacking_velocities - self.velocities[0]) /
                                       (self.velocities[-1] - self.velocities[0]) * self.semblance.shape[1])
 
-        super()._plot(self.semblance, title=title, x_label="Velocity (m/s)", x_ticklabels=self.velocities,
+        super()._plot(self.semblance, title=title, x_label="Velocity", x_ticklabels=self.velocities,
                       x_ticker=x_ticker, y_ticklabels=self.times, y_ticker=y_ticker, ax=ax, grid=grid,
                       stacking_times_ix=stacking_times_ix, stacking_velocities_ix=stacking_velocities_ix,
                       colorbar=colorbar, **kwargs)
@@ -596,7 +596,7 @@ class ResidualSemblance(BaseSemblance):
         stacking_times_ix = stacking_times / self.sample_rate
         stacking_velocities_ix = np.full_like(stacking_times_ix, self.residual_semblance.shape[1] / 2)
 
-        super()._plot(self.residual_semblance, title=title, x_label="Relative velocity margin (%)",
+        super()._plot(self.residual_semblance, title=title, x_label="Relative velocity margin",
                       x_ticklabels=x_ticklabels, x_ticker=x_ticker, y_ticklabels=self.times, y_ticker=y_ticker, ax=ax,
                       grid=grid, stacking_times_ix=stacking_times_ix, stacking_velocities_ix=stacking_velocities_ix,
                       colorbar=colorbar, **kwargs)

--- a/seismicpro/semblance/semblance.py
+++ b/seismicpro/semblance/semblance.py
@@ -329,7 +329,7 @@ class Semblance(BaseSemblance):
             stacking_velocities_ix = ((stacking_velocities - self.velocities[0]) /
                                       (self.velocities[-1] - self.velocities[0]) * self.semblance.shape[1])
 
-        super()._plot(self.semblance, title=title, x_label="Velocity", x_ticklabels=self.velocities,
+        super()._plot(self.semblance, title=title, x_label="Velocity, m/s", x_ticklabels=self.velocities,
                       x_ticker=x_ticker, y_ticklabels=self.times, y_ticker=y_ticker, ax=ax, grid=grid,
                       stacking_times_ix=stacking_times_ix, stacking_velocities_ix=stacking_velocities_ix,
                       colorbar=colorbar, **kwargs)
@@ -596,7 +596,7 @@ class ResidualSemblance(BaseSemblance):
         stacking_times_ix = stacking_times / self.sample_rate
         stacking_velocities_ix = np.full_like(stacking_times_ix, self.residual_semblance.shape[1] / 2)
 
-        super()._plot(self.residual_semblance, title=title, x_label="Relative velocity margin",
+        super()._plot(self.residual_semblance, title=title, x_label="Relative velocity margin, %",
                       x_ticklabels=x_ticklabels, x_ticker=x_ticker, y_ticklabels=self.times, y_ticker=y_ticker, ax=ax,
                       grid=grid, stacking_times_ix=stacking_times_ix, stacking_velocities_ix=stacking_velocities_ix,
                       colorbar=colorbar, **kwargs)

--- a/seismicpro/stacking_velocity/metrics.py
+++ b/seismicpro/stacking_velocity/metrics.py
@@ -88,7 +88,7 @@ class StackingVelocityMetric(Metric):
         for vel in window:
             ax.plot(vel, self.times, color="tab:blue")
         ax.invert_yaxis()
-        set_ticks(ax, "x", "Stacking velocity", **x_ticker)
+        set_ticks(ax, "x", "Stacking velocity, m/s", **x_ticker)
         set_ticks(ax, "y", "Time", **y_ticker)
         ax.set_xlim(*self.velocity_limits)
 

--- a/seismicpro/stacking_velocity/metrics.py
+++ b/seismicpro/stacking_velocity/metrics.py
@@ -88,7 +88,7 @@ class StackingVelocityMetric(Metric):
         for vel in window:
             ax.plot(vel, self.times, color="tab:blue")
         ax.invert_yaxis()
-        set_ticks(ax, "x", "Stacking velocity (m/s)", **x_ticker)
+        set_ticks(ax, "x", "Stacking velocity", **x_ticker)
         set_ticks(ax, "y", "Time", **y_ticker)
         ax.set_xlim(*self.velocity_limits)
 

--- a/seismicpro/tests/test_gather.py
+++ b/seismicpro/tests/test_gather.py
@@ -224,9 +224,10 @@ def test_gather_mask_to_pick_and_pick_to_mask(gather):
     mask = gather.pick_to_mask(first_breaks_col=HDR_FIRST_BREAK)
     mask.mask_to_pick(first_breaks_col=HDR_FIRST_BREAK, save_to=gather)
 
-def test_gather_sort(gather):
+@pytest.mark.parametrize('by', ('offset', ['FieldRecord', 'offset']))
+def test_gather_sort(gather, by):
     """test_gather_sort"""
-    gather.sort(by='offset')
+    gather.sort(by=by)
 
 def test_gather_muting(gather):
     """test_gather_muting"""

--- a/seismicpro/utils/plot_utils.py
+++ b/seismicpro/utils/plot_utils.py
@@ -86,7 +86,7 @@ def format_subplot_yticklabels(ax, fontsize=None, fontfamily=None, fontweight=No
         tick.set_fontweight(fontweight)
 
 
-def set_ticks(ax, axis, label='', major_labels=None, minor_labels=None, num=None, 
+def set_ticks(ax, axis, label='', major_labels=None, minor_labels=None, num=None,
               step_ticks=None, step_labels=None, round_to=0, **kwargs):
     """Set ticks and labels for `x` or `y` axis depending on the `axis`.
 
@@ -135,7 +135,7 @@ def set_ticks(ax, axis, label='', major_labels=None, minor_labels=None, num=None
     }
 
     axis_label = '\n'.join([ix_label + UNITS.get(ix_label, '') for ix_label in to_list(label)])
- 
+
     locator, formatter = _process_ticks(labels=major_labels, num=num, step_ticks=step_ticks,
                                         step_labels=step_labels, round_to=round_to)
     rotation_kwargs = _pop_rotation_kwargs(kwargs)

--- a/seismicpro/utils/plot_utils.py
+++ b/seismicpro/utils/plot_utils.py
@@ -125,16 +125,7 @@ def set_ticks(ax, axis, label='', major_labels=None, minor_labels=None, num=None
     ValueError
         If `step_labels` is provided when tick_labels are None or not monotonically increasing.
     """
-    # Format axis label
-    UNITS = {  # pylint: disable=invalid-name
-        "offset": " (m)",
-        "Time": " (ms)",
-        "Velocity": " (m/s)",
-        "Stacking velocity": " (m/s)",
-        "Relative velocity margin": " (%)"
-    }
-
-    axis_label = '\n'.join([ix_label + UNITS.get(ix_label, '') for ix_label in to_list(label)])
+    axis_label = '\n'.join(to_list(label))
 
     locator, formatter = _process_ticks(labels=major_labels, num=num, step_ticks=step_ticks,
                                         step_labels=step_labels, round_to=round_to)

--- a/seismicpro/utils/plot_utils.py
+++ b/seismicpro/utils/plot_utils.py
@@ -127,9 +127,10 @@ def set_ticks(ax, axis, label='', major_labels=None, minor_labels=None, num=None
     """
     # Format axis label
     UNITS = {  # pylint: disable=invalid-name
-        "Time": " (ms)",
         "offset": " (m)",
+        "Time": " (ms)",
         "Velocity": " (m/s)",
+        "Stacking velocity": " (m/s)",
         "Relative velocity margin": " (%)"
     }
 

--- a/seismicpro/utils/plot_utils.py
+++ b/seismicpro/utils/plot_utils.py
@@ -131,7 +131,7 @@ def set_ticks(ax, axis, label='', major_labels=None, minor_labels=None, num=None
         "Offset": " (m)",
     }
 
-    axis_label = '\n'.join([ix_label.title() + UNITS.get(ix_label, '') for ix_label in to_list(label)])
+    axis_label = '\n'.join([UNITS.get(ix_label, '') for ix_label in to_list(label)])
  
     locator, formatter = _process_ticks(labels=major_labels, num=num, step_ticks=step_ticks,
                                         step_labels=step_labels, round_to=round_to)

--- a/seismicpro/utils/plot_utils.py
+++ b/seismicpro/utils/plot_utils.py
@@ -133,7 +133,7 @@ def set_ticks(ax, axis, labels='', tick_labels=None, num=None, step_ticks=None, 
         major_labels, minor_labels = tick_labels.T[0], tick_labels.T[1]
     else:
         major_labels, minor_labels = tick_labels, None
-    
+
     locator, formatter = _process_ticks(labels=major_labels, num=num, step_ticks=step_ticks,
                                         step_labels=step_labels, round_to=round_to)
     rotation_kwargs = _pop_rotation_kwargs(kwargs)

--- a/seismicpro/utils/plot_utils.py
+++ b/seismicpro/utils/plot_utils.py
@@ -8,8 +8,6 @@ import matplotlib.pyplot as plt
 from matplotlib import ticker
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 
-from .general_utils import to_list
-
 
 def as_dict(val, key):
     """Construct a dict with a {`key`: `val`} structure if given `val` is not a `dict`, or copy `val` otherwise."""

--- a/seismicpro/utils/plot_utils.py
+++ b/seismicpro/utils/plot_utils.py
@@ -4,6 +4,7 @@
 from functools import partial
 
 import numpy as np
+import matplotlib.pyplot as plt
 from matplotlib import ticker
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 
@@ -85,7 +86,8 @@ def format_subplot_yticklabels(ax, fontsize=None, fontfamily=None, fontweight=No
         tick.set_fontweight(fontweight)
 
 
-def set_ticks(ax, axis, label='', tick_labels=None, num=None, step_ticks=None, step_labels=None, round_to=0, **kwargs):
+def set_ticks(ax, axis, label='', major_labels=None, minor_labels=None, num=None, 
+              step_ticks=None, step_labels=None, round_to=0, **kwargs):
     """Set ticks and labels for `x` or `y` axis depending on the `axis`.
 
     Parameters
@@ -96,8 +98,10 @@ def set_ticks(ax, axis, label='', tick_labels=None, num=None, step_ticks=None, s
         Whether to set ticks for "x" or "y" axis of `ax`.
     label : str, optional, defaults to ''
         The label to set for `axis` axis.
-    tick_labels : array-like, optional, defaults to None
-        An array of labels for axis ticks.
+    major_labels : array-like, optional, defaults to None
+        An array of major labels for axis ticks.
+    minor_labels : array-like, optional, defaults to None
+        An array of minor labels for axis ticks.
     num : int, optional, defaults to None
         The number of evenly spaced ticks on the axis.
     step_ticks : int, optional, defaults to None
@@ -127,15 +131,8 @@ def set_ticks(ax, axis, label='', tick_labels=None, num=None, step_ticks=None, s
         "Offset": " (m)",
     }
 
-    label = to_list(label)
-    axis_label = '\n'.join([ix_label[0].upper() + ix_label[1:] + UNITS.get(ix_label, '') for ix_label in label])
-
-    major_labels, minor_labels = None, None
-    if len(label) > 1:
-        major_labels, minor_labels = tick_labels[:, 0], tick_labels[:, 1]
-    elif tick_labels is not None:
-        major_labels, minor_labels = tick_labels.ravel(), None
-
+    axis_label = '\n'.join([ix_label.title() + UNITS.get(ix_label, '') for ix_label in to_list(label)])
+ 
     locator, formatter = _process_ticks(labels=major_labels, num=num, step_ticks=step_ticks,
                                         step_labels=step_labels, round_to=round_to)
     rotation_kwargs = _pop_rotation_kwargs(kwargs)
@@ -149,7 +146,7 @@ def set_ticks(ax, axis, label='', tick_labels=None, num=None, step_ticks=None, s
         _, formatter = _process_ticks(labels=minor_labels, round_to=round_to)
         ax_obj.set_minor_locator(ticker.AutoMinorLocator(n=4))
         ax_obj.set_minor_formatter(formatter)
-        ax_obj.set_tick_params(which='minor', labelsize='small')
+        ax_obj.set_tick_params(which='minor', labelsize=kwargs.get("fontsize", plt.rcParams['font.size']) * 0.8)
 
 
 def _process_ticks(labels, num=None, step_ticks=None, step_labels=None, round_to=0):

--- a/seismicpro/utils/plot_utils.py
+++ b/seismicpro/utils/plot_utils.py
@@ -85,7 +85,7 @@ def format_subplot_yticklabels(ax, fontsize=None, fontfamily=None, fontweight=No
         tick.set_fontweight(fontweight)
 
 
-def set_ticks(ax, axis, labels='', tick_labels=None, num=None, step_ticks=None, step_labels=None, round_to=0, **kwargs):
+def set_ticks(ax, axis, label='', tick_labels=None, num=None, step_ticks=None, step_labels=None, round_to=0, **kwargs):
     """Set ticks and labels for `x` or `y` axis depending on the `axis`.
 
     Parameters
@@ -127,18 +127,19 @@ def set_ticks(ax, axis, labels='', tick_labels=None, num=None, step_ticks=None, 
         "Offset": " (m)",
     }
 
-    label = '\n'.join([label[0].upper() + label[1:] + UNITS.get(label, '') for label in to_list(labels)])
+    label = to_list(label)
+    axis_label = '\n'.join([ix_label[0].upper() + ix_label[1:] + UNITS.get(ix_label, '') for ix_label in label])
 
-    if tick_labels is not None and tick_labels.ndim == 2:
-        major_labels, minor_labels = tick_labels.T[0], tick_labels.T[1]
+    if len(label) > 1:
+        major_labels, minor_labels = tick_labels[:, 0], tick_labels[:, 1]
     else:
-        major_labels, minor_labels = tick_labels, None
+        major_labels, minor_labels = tick_labels.ravel(), None
 
     locator, formatter = _process_ticks(labels=major_labels, num=num, step_ticks=step_ticks,
                                         step_labels=step_labels, round_to=round_to)
     rotation_kwargs = _pop_rotation_kwargs(kwargs)
     ax_obj = getattr(ax, f"{axis}axis")
-    ax_obj.set_label_text(label, **kwargs)
+    ax_obj.set_label_text(axis_label, **kwargs)
     ax_obj.set_ticklabels([], **kwargs, **rotation_kwargs)
     ax_obj.set_major_locator(locator)
     ax_obj.set_major_formatter(formatter)

--- a/seismicpro/utils/plot_utils.py
+++ b/seismicpro/utils/plot_utils.py
@@ -128,7 +128,9 @@ def set_ticks(ax, axis, label='', major_labels=None, minor_labels=None, num=None
     # Format axis label
     UNITS = {  # pylint: disable=invalid-name
         "Time": " (ms)",
-        "Offset": " (m)",
+        "offset": " (m)",
+        "Velocity": " (m/s)",
+        "Relative velocity margin": " (%)"
     }
 
     axis_label = '\n'.join([ix_label + UNITS.get(ix_label, '') for ix_label in to_list(label)])

--- a/seismicpro/utils/plot_utils.py
+++ b/seismicpro/utils/plot_utils.py
@@ -130,9 +130,10 @@ def set_ticks(ax, axis, label='', tick_labels=None, num=None, step_ticks=None, s
     label = to_list(label)
     axis_label = '\n'.join([ix_label[0].upper() + ix_label[1:] + UNITS.get(ix_label, '') for ix_label in label])
 
+    major_labels, minor_labels = None, None
     if len(label) > 1:
         major_labels, minor_labels = tick_labels[:, 0], tick_labels[:, 1]
-    else:
+    elif tick_labels is not None:
         major_labels, minor_labels = tick_labels.ravel(), None
 
     locator, formatter = _process_ticks(labels=major_labels, num=num, step_ticks=step_ticks,

--- a/seismicpro/utils/plot_utils.py
+++ b/seismicpro/utils/plot_utils.py
@@ -125,13 +125,11 @@ def set_ticks(ax, axis, label='', major_labels=None, minor_labels=None, num=None
     ValueError
         If `step_labels` is provided when tick_labels are None or not monotonically increasing.
     """
-    axis_label = '\n'.join(to_list(label))
-
     locator, formatter = _process_ticks(labels=major_labels, num=num, step_ticks=step_ticks,
                                         step_labels=step_labels, round_to=round_to)
     rotation_kwargs = _pop_rotation_kwargs(kwargs)
     ax_obj = getattr(ax, f"{axis}axis")
-    ax_obj.set_label_text(axis_label, **kwargs)
+    ax_obj.set_label_text(label, **kwargs)
     ax_obj.set_ticklabels([], **kwargs, **rotation_kwargs)
     ax_obj.set_major_locator(locator)
     ax_obj.set_major_formatter(formatter)

--- a/seismicpro/utils/plot_utils.py
+++ b/seismicpro/utils/plot_utils.py
@@ -131,7 +131,7 @@ def set_ticks(ax, axis, label='', major_labels=None, minor_labels=None, num=None
         "Offset": " (m)",
     }
 
-    axis_label = '\n'.join([UNITS.get(ix_label, '') for ix_label in to_list(label)])
+    axis_label = '\n'.join([ix_label + UNITS.get(ix_label, '') for ix_label in to_list(label)])
  
     locator, formatter = _process_ticks(labels=major_labels, num=num, step_ticks=step_ticks,
                                         step_labels=step_labels, round_to=round_to)


### PR DESCRIPTION
`gather.sort()` now can work with multiple headers, e.g. `gather.sort(['INLINE_3D', 'CROSSLINE_3D'])`

The `gather.sort_by` attribute is latter is used in `gather.plot()` to infer axis ticks. 
In case `gather` is sorted by two headers, add minor ticks to handle minor header, e.g.

`gather.sort(['SourceWaterDepath', 'GroupWaterDepth']).plot()`
![image](https://user-images.githubusercontent.com/8656643/206468670-3494150b-ba40-4a9e-898b-773b8f196ed2.png)
