### PR TITLE
Fields bugfixes

### DIFF
--- a/seismicpro/muter/muter_field.py
+++ b/seismicpro/muter/muter_field.py
@@ -72,8 +72,11 @@ class MuterField(ValuesAgnosticField, VFUNCFieldMixin):
         Whether coordinate system of the field is geographic. `None` for an empty field if was not specified during
         instantiation.
     coords_cols : tuple with 2 elements or None
-        Names of SEG-Y trace headers representing coordinates of items in the field. `None` if names of coordinates are
-        mixed or the field is empty.
+        Names of SEG-Y trace headers representing coordinates of items in the field if names are the same among all the
+        items and match the geographic system of the field. ("X", "Y") for a field in geographic coordinate system if
+        names of coordinates of its items are either mixed or line-based. ("INLINE_3D", "CROSSLINE_3D") for a field in
+        line-based coordinate system if names of coordinates of its items are either mixed or geographic. `None` for an
+        empty field.
     interpolator : SpatialInterpolator or None
         Field data interpolator.
     is_dirty_interpolator : bool

--- a/seismicpro/refractor_velocity/interactive_plot.py
+++ b/seismicpro/refractor_velocity/interactive_plot.py
@@ -43,10 +43,7 @@ class FieldPlot(PairedPlot):  # pylint: disable=too-many-instance-attributes
             [f"v{i} - Velocity of refractor {i}" for i in range(1, field.n_refractors + 1)]
         )
 
-        coords_cols = self.field.coords_cols
-        if coords_cols is None:
-            coords_cols = ["X", "Y"] if self.field.is_geographic else ["INLINE_3D", "CROSSLINE_3D"]
-        param_maps = [MetricMap(self.coords, col, coords_cols=coords_cols) for col in self.values.T]
+        param_maps = [MetricMap(self.coords, col, coords_cols=self.field.coords_cols) for col in self.values.T]
         self.plot_fn = [partial(param_map._plot, title="", **kwargs) for param_map in param_maps]
         self.init_click_coords = param_maps[0].get_worst_coords()
 

--- a/seismicpro/refractor_velocity/refractor_velocity.py
+++ b/seismicpro/refractor_velocity/refractor_velocity.py
@@ -400,10 +400,14 @@ class RefractorVelocity:
         if negative_params:
             raise ValueError(f"The following parameters contain negative values: {negative_params}")
 
-        if np.any(np.diff(param_values[1:n_refractors], prepend=0, append=max_offset) < min_refractor_size):
+        refractor_sizes = np.diff(param_values[1:n_refractors], prepend=0, append=max_offset)
+        valid_sizes = (refractor_sizes >= min_refractor_size) | np.isclose(refractor_sizes, min_refractor_size)
+        if not valid_sizes.all():
             raise ValueError(f"Offset range covered by refractors must be no less than {min_refractor_size} meters")
 
-        if np.any(np.diff(param_values[n_refractors:]) < min_velocity_step):
+        velocity_steps = np.diff(param_values[n_refractors:])
+        valid_steps = (velocity_steps >= min_velocity_step) | np.isclose(velocity_steps, min_velocity_step)
+        if not valid_steps.all():
             raise ValueError(f"Refractor velocities must increase by no less than {min_velocity_step} m/s")
 
     @classmethod

--- a/seismicpro/refractor_velocity/refractor_velocity.py
+++ b/seismicpro/refractor_velocity/refractor_velocity.py
@@ -364,9 +364,9 @@ class RefractorVelocity:
 
     def __getattr__(self, key):
         """Get requested parameter of the velocity model by its name."""
-        if key.startswith("__"):  # Guarantee proper pickling/unpickling
+        if key.startswith("__") or key not in self.params:  # Guarantee proper pickling/unpickling
             raise AttributeError(f"'{type(self).__name__}' object has no attribute '{key}'")
-        return getattr(self.params, key)
+        return self.params[key]
 
     def __call__(self, offsets):
         """Return the expected times of first breaks for the given offsets."""

--- a/seismicpro/refractor_velocity/refractor_velocity_field.py
+++ b/seismicpro/refractor_velocity/refractor_velocity_field.py
@@ -104,8 +104,11 @@ class RefractorVelocityField(SpatialField):
         Whether coordinate system of the field is geographic. `None` for an empty field if was not specified during
         instantiation.
     coords_cols : tuple with 2 elements or None
-        Names of SEG-Y trace headers representing coordinates of items in the field. `None` if names of coordinates are
-        mixed or the field is empty.
+        Names of SEG-Y trace headers representing coordinates of items in the field if names are the same among all the
+        items and match the geographic system of the field. ("X", "Y") for a field in geographic coordinate system if
+        names of coordinates of its items are either mixed or line-based. ("INLINE_3D", "CROSSLINE_3D") for a field in
+        line-based coordinate system if names of coordinates of its items are either mixed or geographic. `None` for an
+        empty field.
     interpolator : SpatialInterpolator or None
         Field data interpolator.
     is_dirty_interpolator : bool
@@ -332,8 +335,8 @@ class RefractorVelocityField(SpatialField):
         self : RefractorVelocityField
             `self` with new items added. Changes `item_container` inplace and sets the `is_dirty_interpolator` flag to
             `True` if the `items` list is not empty. Sets `is_geographic` flag and `n_refractors` attribute during the
-            first update if they were not defined during field creation. Resets `coords_cols` attribute if headers,
-            defining coordinates of any item being added, differ from those of the field.
+            first update if they were not defined during field creation. Updates `coords_cols` attribute if names of
+            coordinates of any item being added does not match those of the field.
 
         Raises
         ------

--- a/seismicpro/stacking_velocity/stacking_velocity_field.py
+++ b/seismicpro/stacking_velocity/stacking_velocity_field.py
@@ -89,8 +89,11 @@ class StackingVelocityField(ValuesAgnosticField, VFUNCFieldMixin):
         Whether coordinate system of the field is geographic. `None` for an empty field if was not specified during
         instantiation.
     coords_cols : tuple with 2 elements or None
-        Names of SEG-Y trace headers representing coordinates of items in the field. `None` if names of coordinates are
-        mixed or the field is empty.
+        Names of SEG-Y trace headers representing coordinates of items in the field if names are the same among all the
+        items and match the geographic system of the field. ("X", "Y") for a field in geographic coordinate system if
+        names of coordinates of its items are either mixed or line-based. ("INLINE_3D", "CROSSLINE_3D") for a field in
+        line-based coordinate system if names of coordinates of its items are either mixed or geographic. `None` for an
+        empty field.
     interpolator : SpatialInterpolator or None
         Field data interpolator.
     is_dirty_interpolator : bool

--- a/seismicpro/utils/coordinates.py
+++ b/seismicpro/utils/coordinates.py
@@ -37,7 +37,7 @@ def get_coords_cols(index_cols):
     return coords_cols
 
 
-GEOGRAPHIC_COORDS = {("SourceX", "SourceY"), ("GroupX", "GroupY"), ("CDP_X", "CDP_Y")}
+GEOGRAPHIC_COORDS = {("X", "Y"), ("SourceX", "SourceY"), ("GroupX", "GroupY"), ("CDP_X", "CDP_Y")}
 LINE_COORDS = {("INLINE_3D", "CROSSLINE_3D"), ("SUPERGATHER_INLINE_3D", "SUPERGATHER_CROSSLINE_3D")}
 ALLOWED_COORDS = GEOGRAPHIC_COORDS | LINE_COORDS
 


### PR DESCRIPTION
Fixed several small bugs appeared during processing of last surveys:
* Now `RefractorVelocity.__getattr__` works as expected: previously `rv.t0` failed,
* Added tolerances in `RefractorVelocity._validate_params` checks. Previously they may have failed to fit a velocity model for noisy first breaks. Was also mentioned in https://github.com/gazprom-neft/SeismicPro/pull/107, but not completely fixed,
* Fixed a rare bug when IDW interpolation within a given radius resulted in `nan` values due to inaccuracies in floating-point arithmetics,
* Fixed processing of `coords_cols` during a field update: e.g. previously `RefractorVelocityField.from_survey(survey, n_refractors=1, is_geographic=True)` produced wrong results if `survey` was indexed by line-based coordinates.