### PR TITLE
Handle uphole correction

### DIFF
--- a/seismicpro/containers.py
+++ b/seismicpro/containers.py
@@ -139,7 +139,7 @@ class TraceContainer:
         else:
             # FIXME: Workaround for a pandas bug https://github.com/pandas-dev/pandas/issues/34822
             # raw=True causes incorrect apply behavior when axis=1 and multiple values are returned from `func`
-            raw = (axis != 1)
+            raw = axis != 1
 
             apply_func = (lambda args, **kwargs: func(*args, **kwargs)) if unpack_args else func
             res = df.apply(apply_func, axis=axis, raw=raw, result_type="expand", **kwargs)

--- a/seismicpro/containers.py
+++ b/seismicpro/containers.py
@@ -48,6 +48,11 @@ class TraceContainer:
         return index_names
 
     @property
+    def available_headers(self):
+        """set of str: Names of available trace headers: both loaded and created manually."""
+        return set(self.headers.columns) | set(self.headers.index.names)
+
+    @property
     def n_traces(self):
         """int: The number of traces."""
         return len(self.headers)

--- a/seismicpro/gather/gather.py
+++ b/seismicpro/gather/gather.py
@@ -884,8 +884,8 @@ class Gather(TraceContainer, SamplesContainer):
             Headers columns which will be LMO-corrected inplace.
         correct_uphole : bool, optional
             Whether to perform uphole correction by adding values of "SourceUpholeTime" header to estimated delay
-            times. If not given, correction is performed if "SourceUpholeTime" header is loaded and given
-            `refractor_velocity` was also uphole corrected.
+            times. If enabled, centers first breaks around `delay` for uphole surveys. If not given, correction is
+            performed if "SourceUpholeTime" header is loaded and given `refractor_velocity` was also uphole corrected.
 
         Returns
         -------

--- a/seismicpro/gather/gather.py
+++ b/seismicpro/gather/gather.py
@@ -906,7 +906,7 @@ class Gather(TraceContainer, SamplesContainer):
                              "type")
 
         trace_delays = delay - refractor_velocity(self.offsets)
-        if correct_uphole:
+        if correct_uphole is None:
             correct_uphole = "SourceUpholeTime" in self.available_headers and refractor_velocity.is_uphole_corrected
         if correct_uphole:
             trace_delays += self["SourceUpholeTime"]

--- a/seismicpro/gather/gather.py
+++ b/seismicpro/gather/gather.py
@@ -364,7 +364,7 @@ class Gather(TraceContainer, SamplesContainer):
         trace_ids = self["TRACE_SEQUENCE_FILE"] - 1
 
         # Keep only headers, defined by SEG-Y standard.
-        used_header_names = (set(to_list(self.indexed_by)) | set(self.headers.columns)) & set(segyio.tracefield.keys)
+        used_header_names = self.available_headers & set(segyio.tracefield.keys)
         used_header_names = to_list(used_header_names)
 
         # Transform header's names into byte number based on the SEG-Y standard.
@@ -693,7 +693,7 @@ class Gather(TraceContainer, SamplesContainer):
     @batch_method(target="for", copy_src=False)  # pylint: disable-next=too-many-arguments
     def calculate_refractor_velocity(self, init=None, bounds=None, n_refractors=None, max_offset=None,
                                      min_velocity_step=1, min_refractor_size=1, loss="L1", huber_coef=20, tol=1e-5,
-                                     first_breaks_col=HDR_FIRST_BREAK, **kwargs):
+                                     first_breaks_col=HDR_FIRST_BREAK, correct_uphole=None, **kwargs):
         """Fit a near-surface velocity model by offsets of traces and times of their first breaks.
 
         Notes
@@ -731,6 +731,10 @@ class Gather(TraceContainer, SamplesContainer):
             Precision goal for the value of loss in the stopping criterion.
         first_breaks_col : str, optional, defaults to :const:`~const.HDR_FIRST_BREAK`
             Column name from `self.headers` where times of first break are stored.
+        correct_uphole : bool, optional
+            Whether to perform uphole correction by adding values of "SourceUpholeTime" header to times of first breaks
+            emulating the case when sources are located on the surface. If not given, correction is performed if
+            "SourceUpholeTime" header is loaded.
         kwargs : misc, optional
             Additional `SLSQP` options, see https://docs.scipy.org/doc/scipy/reference/optimize.minimize-slsqp.html for
             more details.
@@ -740,9 +744,14 @@ class Gather(TraceContainer, SamplesContainer):
         rv : RefractorVelocity
             Constructed near-surface velocity model.
         """
-        return RefractorVelocity.from_first_breaks(self.offsets, self[first_breaks_col], init, bounds, n_refractors,
-                                                   max_offset, min_velocity_step, min_refractor_size, loss, huber_coef,
-                                                   tol, coords=self.coords, **kwargs)
+        times = self[first_breaks_col]
+        if correct_uphole is None:
+            correct_uphole = "SourceUpholeTime" in self.available_headers
+        if correct_uphole:
+            times = times + self["SourceUpholeTime"]
+        return RefractorVelocity.from_first_breaks(self.offsets, times, init, bounds, n_refractors, max_offset,
+                                                   min_velocity_step, min_refractor_size, loss, huber_coef, tol,
+                                                   coords=self.coords, is_uphole_corrected=correct_uphole, **kwargs)
 
     #------------------------------------------------------------------------#
     #                         Gather muting methods                          #

--- a/seismicpro/metrics/interactive_map.py
+++ b/seismicpro/metrics/interactive_map.py
@@ -101,8 +101,8 @@ class MapBinPlot(MapCoordsPlot):
         self.drop.observe(self.select_option, names="value")
 
         self.sort.disabled = False
-        self.prev.disabled = (self.curr_option == 0)
-        self.next.disabled = (self.curr_option == (len(self.options) - 1))
+        self.prev.disabled = self.curr_option == 0
+        self.next.disabled = self.curr_option == (len(self.options) - 1)
 
         if redraw:
             self.redraw()

--- a/seismicpro/refractor_velocity/refractor_velocity_field.py
+++ b/seismicpro/refractor_velocity/refractor_velocity_field.py
@@ -132,10 +132,11 @@ class RefractorVelocityField(SpatialField):
 
     @cached_property
     def is_uphole_corrected(self):
-        """bool or None: Whether the field is uphole corrected. `None` if unknown."""
-        if any(item.is_uphole_corrected is None for item in self.items):
+        """bool or None: Whether the field is uphole corrected. `None` if unknown or mixed items are stored."""
+        is_uphole_corrected_set = {item.is_uphole_corrected for item in self.items}
+        if len(is_uphole_corrected_set) != 1:
             return None
-        return all(item.is_uphole_corrected for item in self.items)
+        return is_uphole_corrected_set.pop()
 
     @cached_property
     def is_fit(self):

--- a/seismicpro/refractor_velocity/refractor_velocity_field.py
+++ b/seismicpro/refractor_velocity/refractor_velocity_field.py
@@ -128,6 +128,13 @@ class RefractorVelocityField(SpatialField):
         return get_param_names(self.n_refractors)
 
     @cached_property
+    def is_uphole_corrected(self):
+        """bool or None: Whether the field is uphole corrected. `None` if unknown."""
+        if any(item.is_uphole_corrected is None for item in self.items):
+            return None
+        return all(item.is_uphole_corrected for item in self.items)
+
+    @cached_property
     def is_fit(self):
         """bool: Whether the field was constructed directly from offset-traveltime data."""
         return all(item.is_fit for item in self.items)
@@ -143,6 +150,7 @@ class RefractorVelocityField(SpatialField):
         msg = super().__str__() + dedent(f"""\n
         Number of refractors:      {self.n_refractors}
         Is fit from first breaks:  {self.is_fit}
+        Is uphole corrected:       {self.is_uphole_corrected}
         """)
 
         if not self.is_empty:

--- a/seismicpro/refractor_velocity/utils.py
+++ b/seismicpro/refractor_velocity/utils.py
@@ -62,7 +62,7 @@ def load_refractor_velocities(path, encoding="UTF-8"):
     """
     #pylint: disable-next=import-outside-toplevel
     from .refractor_velocity import RefractorVelocity  # import inside to avoid the circular import
-    df = pd.read_csv(path, sep=r'\s+', dtype={"is_uphole_corrected": "string"}, encoding="UTF-8")
+    df = pd.read_csv(path, sep=r'\s+', dtype={"is_uphole_corrected": "string"}, encoding=encoding)
     df["is_uphole_corrected"] = df["is_uphole_corrected"].map({"None": None, "True": True, "False": False})
     params_names = df.columns[5:]
     return [RefractorVelocity(**dict(zip(params_names, row[5:])), coords=Coordinates(row[2:4], row[:2]),

--- a/seismicpro/refractor_velocity/utils.py
+++ b/seismicpro/refractor_velocity/utils.py
@@ -18,7 +18,7 @@ def postprocess_params(params):
     - Crossover offsets are non-negative and increasing,
     - Velocities of refractors are non-negative and increasing.
     """
-    is_1d = (params.ndim == 1)
+    is_1d = params.ndim == 1
 
     # Ensure that all params are non-negative
     params = np.clip(np.atleast_2d(params), 0, None)

--- a/seismicpro/survey/headers.py
+++ b/seismicpro/survey/headers.py
@@ -113,10 +113,10 @@ def validate_headers(headers, offset_atol=10, cdp_atol=10, elev_atol=5, elev_rad
     headers = headers.copy(deep=False)
     headers.reset_index(inplace=True)
 
-    loaded_columns = headers.columns.values
-    available_columns = set(loaded_columns[headers.any(axis=0)])
+    loaded_columns = set(headers.columns)
+    available_columns = set(headers.columns[headers.any(axis=0)])
 
-    zero_columns = set(loaded_columns) - available_columns
+    zero_columns = loaded_columns - available_columns
     if zero_columns:
         msg_list.append("Empty headers: " + ", ".join(zero_columns))
 

--- a/seismicpro/survey/headers.py
+++ b/seismicpro/survey/headers.py
@@ -129,6 +129,22 @@ def validate_headers(headers, offset_atol=10, cdp_atol=10, elev_atol=5, elev_rad
         if fr_with_coords.duplicated('FieldRecord').any() or fr_with_coords.duplicated(shot_cols).any():
             msg_list.append("Non-unique mapping of source coordinates (SourceX, SourceY) and source ID (FieldRecord)")
 
+    if "SourceUpholeTime" in available_columns:
+        if (headers["SourceUpholeTime"] < 0).any():
+            msg_list.append("Negative uphole times")
+
+    if "SourceDepth" in available_columns:
+        if (headers["SourceDepth"] < 0).any():
+            msg_list.append("Negative uphole depths")
+
+    if {"SourceUpholeTime", "SourceDepth"} <= loaded_columns:
+        zero_time_mask = np.isclose(headers["SourceUpholeTime"], 0)
+        zero_depth_mask = np.isclose(headers["SourceDepth"], 0)
+        if (~zero_time_mask[zero_depth_mask]).any():
+            msg_list.append("Non-zero uphole time for zero uphole depth")
+        if (~zero_depth_mask[zero_time_mask]).any():
+            msg_list.append("Non-zero uphole depth for zero uphole time")
+
     if 'offset' in available_columns:
         if (headers['offset'] < 0).any():
             msg_list.append("Signed offsets")

--- a/seismicpro/survey/survey.py
+++ b/seismicpro/survey/survey.py
@@ -314,9 +314,8 @@ class Survey(GatherContainer, SamplesContainer):  # pylint: disable=too-many-ins
     @property
     def is_uphole(self):
         """bool or None: Whether the survey is uphole. `None` if uphole-related headers are not loaded."""
-        all_headers = set(self.headers.columns) | set(self.headers.index.names)
-        has_uphole_times = "SourceUpholeTime" in all_headers
-        has_uphole_depths = "SourceDepth" in all_headers
+        has_uphole_times = "SourceUpholeTime" in self.available_headers
+        has_uphole_depths = "SourceDepth" in self.available_headers
         has_positive_uphole_times = has_uphole_times and (self["SourceUpholeTime"] > 0).any()
         has_positive_uphole_depths = has_uphole_depths and (self["SourceDepth"] > 0).any()
         if not has_uphole_times and not has_uphole_depths:

--- a/seismicpro/survey/survey.py
+++ b/seismicpro/survey/survey.py
@@ -496,7 +496,7 @@ class Survey(GatherContainer, SamplesContainer):  # pylint: disable=too-many-ins
         self._bins_to_coords_reg = bins_to_coords_reg
         self._coords_to_bins_reg = coords_to_bins_reg
         self.n_bins = len(bins_to_coords)
-        self.is_stacked = (self.n_traces == self.n_bins)
+        self.is_stacked = self.n_traces == self.n_bins
         self.bin_size = np.diag(sp.linalg.polar(bins_to_coords_reg.coef_)[1])
         self.inline_length = (np.ptp(bins_to_coords["INLINE_3D"]) + 1) * self.bin_size[0]
         self.crossline_length = (np.ptp(bins_to_coords["CROSSLINE_3D"]) + 1) * self.bin_size[1]
@@ -513,7 +513,7 @@ class Survey(GatherContainer, SamplesContainer):  # pylint: disable=too-many-ins
         if transformer is None:
             raise ValueError("Survey geometry was not inferred, call `infer_geometry` method first.")
         coords = np.array(coords)
-        is_coords_1d = (coords.ndim == 1)
+        is_coords_1d = coords.ndim == 1
         coords = np.atleast_2d(coords)
         transformed_coords = transformer.predict(coords)
         if is_coords_1d:
@@ -574,7 +574,7 @@ class Survey(GatherContainer, SamplesContainer):  # pylint: disable=too-many-ins
         if contours is None:
             raise ValueError("Survey geometry was not inferred, call `infer_geometry` method first.")
         coords = np.array(coords, dtype=np.float32)
-        is_coords_1d = (coords.ndim == 1)
+        is_coords_1d = coords.ndim == 1
         coords = np.atleast_2d(coords)
         dist = np.empty(len(coords), dtype=np.float32)
         for i, coord in enumerate(coords):

--- a/seismicpro/tests/test_dump_merge.py
+++ b/seismicpro/tests/test_dump_merge.py
@@ -51,10 +51,10 @@ def test_dump_single_gather(segy_path, tmp_path, name, retain_parent_segy_header
         assert full_exp_headers.equals(full_dump_headers)
 
 
-@pytest.mark.parametrize("dump_kwargs, error",
+@pytest.mark.parametrize("dump_kwargs, error", [
     ({"path": ""}, FileNotFoundError),
     ({"path": "some_path", "name": ""}, ValueError)
-)
+])
 def test_dump_single_gather_with_invalid_kwargs(segy_path, dump_kwargs, error):
     survey = Survey(segy_path, header_index='FieldRecord', validate=False)
     gather = survey.get_gather(1)

--- a/seismicpro/tests/test_dump_merge.py
+++ b/seismicpro/tests/test_dump_merge.py
@@ -51,9 +51,10 @@ def test_dump_single_gather(segy_path, tmp_path, name, retain_parent_segy_header
         assert full_exp_headers.equals(full_dump_headers)
 
 
-@pytest.mark.parametrize('dump_kwargs,error',
-                         ((dict(path=''), FileNotFoundError),
-                          (dict(path='somepath', name=''), ValueError)))
+@pytest.mark.parametrize("dump_kwargs, error",
+    ({"path": ""}, FileNotFoundError),
+    ({"path": "some_path", "name": ""}, ValueError)
+)
 def test_dump_single_gather_with_invalid_kwargs(segy_path, dump_kwargs, error):
     survey = Survey(segy_path, header_index='FieldRecord', validate=False)
     gather = survey.get_gather(1)

--- a/seismicpro/tests/test_segy_generator.py
+++ b/seismicpro/tests/test_segy_generator.py
@@ -9,13 +9,14 @@ import pytest
 from seismicpro import Survey, make_prestack_segy
 
 
-@pytest.fixture(scope='module',
-                params=[dict(survey_area=(500,500), activation_dist=(500,500), bin_size=(50,50), samples=1500,
-                             sources_step=(300,50), recievers_step=(100,25)),
-                        dict(survey_area=(1200,1200), activation_dist=(300,300), bin_size=(30,30), samples=100,
-                             sources_step=(200,50), recievers_step=(100,25)),
-                        dict(survey_area=(100,100), activation_dist=(100,100), bin_size=(100,100), samples=1000,
-                             sources_step=(300,50), recievers_step=(200,50))])
+@pytest.fixture(scope="module", params=[
+    {"survey_area": (500, 500), "activation_dist": (500, 500), "bin_size": (50, 50), "samples": 1500,
+     "sources_step": (300, 50), "receivers_step": (100, 25)},
+    {"survey_area": (1200, 1200), "activation_dist": (300, 300), "bin_size": (30, 30), "samples": 100,
+     "sources_step": (200, 50), "receivers_step": (100, 25)},
+    {"survey_area": (100, 100), "activation_dist": (100, 100), "bin_size": (100, 100), "samples": 1000,
+     "sources_step": (300, 50), "receivers_step": (200, 50)},
+])
 def segy_path(request):
     """ Fixture that creates segy file """
     folder = 'test_tmp'

--- a/seismicpro/utils/interactive_plot_utils.py
+++ b/seismicpro/utils/interactive_plot_utils.py
@@ -503,8 +503,8 @@ class DropdownViewPlot(InteractivePlot):
         """Set the current view of the plot to the given `view`."""
         super().set_view(view)
         self.drop.index = view
-        self.prev.disabled = (view == 0)
-        self.next.disabled = (view == (self.n_views - 1))
+        self.prev.disabled = view == 0
+        self.next.disabled = view == (self.n_views - 1)
 
     def next_view(self, event):
         """Switch to the next view."""

--- a/seismicpro/utils/interpolation/spatial.py
+++ b/seismicpro/utils/interpolation/spatial.py
@@ -34,7 +34,7 @@ def parse_inputs(coords, values=None):
     (n_coords, n_values). Check correctness and consistency of shapes. If `values` are not passed, only `coords` are
     processed."""
     coords = np.array(coords, order="C")
-    is_coords_1d = (coords.ndim == 1)
+    is_coords_1d = coords.ndim == 1
     coords = np.atleast_2d(coords)
     if coords.ndim != 2 or coords.shape[1] != 2:
         raise ValueError("coords must have shape (n_coords, 2) or (2,)")
@@ -42,7 +42,7 @@ def parse_inputs(coords, values=None):
         return coords, is_coords_1d, None, None
 
     values = np.array(values, dtype=np.float64, order="C")
-    is_values_1d = (values.ndim == 1)
+    is_values_1d = values.ndim == 1
     if is_values_1d and is_coords_1d:
         is_values_1d = False
         values = np.atleast_2d(coords)
@@ -221,7 +221,7 @@ class IDWInterpolator(ValuesAgnosticInterpolator):
 
     def _distances_to_weights(self, dist):
         """Convert distances to neighboring points into weights."""
-        is_1d_dist = (dist.ndim == 1)
+        is_1d_dist = dist.ndim == 1
         dist = np.atleast_2d(dist)
 
         # Transform distances according to dist_transform and smooth them if needed
@@ -281,7 +281,7 @@ class IDWInterpolator(ValuesAgnosticInterpolator):
         defined by `radius`. Also returns a mask of items in `coords` with empty neighborhood."""
         n_radius_points = self.nearest_neighbors.query_ball_point(coords, r=self.radius, return_length=True,
                                                                   workers=-1)
-        empty_radius_mask = (n_radius_points == 0)
+        empty_radius_mask = n_radius_points == 0
         if empty_radius_mask.all():
             return np.empty((0, 0)), np.empty((0, 0)), empty_radius_mask
 

--- a/seismicpro/utils/interpolation/univariate.py
+++ b/seismicpro/utils/interpolation/univariate.py
@@ -57,7 +57,7 @@ class interp1d:
             Interpolated values, matching the length of `x`.
         """
         x = np.array(x)
-        is_scalar_input = (x.ndim == 0)
+        is_scalar_input = x.ndim == 0
         res = interpolate(x.ravel(), self.x, self.y, self.left_slope, self.right_slope)
         return res.item() if is_scalar_input else res
 
@@ -145,7 +145,7 @@ def calculate_basis_polynomials(x_new, x, n):
 @njit(nogil=True, parallel=True)
 def piecewise_polynomial(x_new, x, y, n):
     """" Perform piecewise polynomial (with degree n) interpolation . Note, x is expected to be sorted. """
-    is_1d = (y.ndim == 1)
+    is_1d = y.ndim == 1
     y = np.atleast_2d(y)
     res = np.zeros((len(y), len(x_new)), dtype=y.dtype)
 


### PR DESCRIPTION
- `Survey` now has an `is_uphole` property, which is calculated by values of `SourceUpholeTime` and `SourceDepth` headers if they are loaded. Consistency of these headers is now checked in `validate_headers`.
- `Gather.calculate_refractor_velocity` and `RefractorVelocityField.from_survey` now accept a `correct_uphole` flag which specifies whether to perform uphole correction by adding values of `SourceUpholeTime` header to times of first breaks or not. This emulates the case when sources are located on the surface. By default, correction is performed if `SourceUpholeTime` header is loaded.
- `RefractorVelocity` now has an `is_uphole_corrected` attribute which is set on construction. `RefractorVelocityField` now has an `is_uphole_corrected` property which is inferred by its items.
- `Gather.apply_lmo` and `FirstBreaksOutliers` metric now properly handle uphole data via their `correct_uphole` flag.
- Upholes are by design not handled in `Muter`, constructed from `RefractorVelocity`: although it seems useful for shot gathers, muting boundary becomes noisy for CDP gathers, which contain traces from multiple shots with varying uphole times. Moreover, similar behavior may be obtained by increasing `delay` on muter construction.