### PR TITLE
Introduce source and receiver ID cols

### DIFF
--- a/seismicpro/containers.py
+++ b/seismicpro/containers.py
@@ -58,8 +58,9 @@ class TraceContainer:
         return len(self.headers)
 
     def __getitem__(self, key):
-        """Select values of trace headers by their names. Unlike `pandas` indexing allows for selection of headers the
-        container is indexed by. The returned array will be 1d if a single header is selected and 2d otherwise.
+        """Select values of trace headers by their names and return them as a `np.ndarray`. Unlike `pandas` indexing
+        allows for selection of headers the container is indexed by. The returned array will be 1d if a single header
+        is selected and 2d otherwise.
 
         Parameters
         ----------
@@ -84,6 +85,22 @@ class TraceContainer:
             Headers values to set.
         """
         self.headers[key] = value
+
+    def get_headers(self, cols):
+        """Select values of trace headers by their names and return them as a `pandas.DataFrame`. Unlike `pandas`
+        indexing allows for selection of headers the container is indexed by.
+
+        Parameters
+        ----------
+        cols : str or list of str
+            Names of headers to get values for.
+
+        Returns
+        -------
+        result : pandas.DataFrame
+            Headers values.
+        """
+        return pd.DataFrame(self[cols], columns=to_list(cols))
 
     def copy(self, ignore=None):
         """Perform a deepcopy of all attributes of `self` except for those specified in `ignore`, which are kept
@@ -196,7 +213,7 @@ class TraceContainer:
         """
         self = maybe_copy(self, inplace, ignore="headers")  # pylint: disable=self-cls-assignment
         cols = to_list(cols)
-        headers = pd.DataFrame(self[cols], columns=cols)
+        headers = self.get_headers(cols)
         mask = self._apply(cond, headers, axis=axis, unpack_args=unpack_args, **kwargs)
         if (mask.ndim != 2) or (mask.shape[1] != 1):
             raise ValueError("cond must return a single value for each header row")
@@ -250,7 +267,7 @@ class TraceContainer:
         """
         self = maybe_copy(self, inplace)  # pylint: disable=self-cls-assignment
         cols = to_list(cols)
-        headers = pd.DataFrame(self[cols], columns=cols)
+        headers = self.get_headers(cols)
         res_cols = cols if res_cols is None else to_list(res_cols)
         res = self._apply(func, headers, axis=axis, unpack_args=unpack_args, **kwargs)
         self.headers[res_cols] = res

--- a/seismicpro/dataset.py
+++ b/seismicpro/dataset.py
@@ -121,8 +121,8 @@ class SeismicDataset(Dataset):
     def __str__(self):
         """Print dataset metadata including information about its batch class and index."""
         msg = f"""
-        Batch class:               {self.batch_class}
-        Index class:               {type(self.index)}
+        Batch class:               {self.batch_class.__name__}
+        Index class:               {type(self.index).__name__}
 
         """
         return (dedent(msg) + str(self.index)).strip()

--- a/seismicpro/gather/gather.py
+++ b/seismicpro/gather/gather.py
@@ -206,7 +206,7 @@ class Gather(TraceContainer, SamplesContainer):
         """Print gather metadata including information about its survey, headers and traces."""
         # Calculate offset range
         offsets = self.headers.get('offset')
-        offset_range = f'[{np.min(offsets)} m, {np.max(offsets)} m]' if offsets is not None else None
+        offset_range = f'[{np.min(offsets)} m, {np.max(offsets)} m]' if offsets is not None else "Unknown"
 
         # Count the number of zero/constant traces
         n_dead_traces = np.isclose(np.max(self.data, axis=1), np.min(self.data, axis=1)).sum()
@@ -215,16 +215,16 @@ class Gather(TraceContainer, SamplesContainer):
         Parent survey path:          {self.survey.path}
         Parent survey name:          {self.survey.name}
 
-        Indexed by:                  {', '.join(to_list(self.indexed_by))}
-        Index value:                 {'Combined' if self.index is None else self.index}
-        Gather coordinates:          {get_first_defined(self.coords, "Unknown")}
-        Gather sorting:              {self.sort_by}
-
         Number of traces:            {self.n_traces}
         Trace length:                {self.n_samples} samples
         Sample rate:                 {self.sample_rate} ms
         Times range:                 [{min(self.samples)} ms, {max(self.samples)} ms]
         Offsets range:               {offset_range}
+
+        Indexed by:                  {', '.join(to_list(self.indexed_by))}
+        Index value:                 {get_first_defined(self.index, "Combined")}
+        Gather coordinates:          {get_first_defined(self.coords, "Unknown")}
+        Gather sorting:              {self.sort_by}
 
         Gather statistics:
         Number of dead traces:       {n_dead_traces}

--- a/seismicpro/gather/gather.py
+++ b/seismicpro/gather/gather.py
@@ -119,9 +119,9 @@ class Gather(TraceContainer, SamplesContainer):
         """Coordinates or None: Spatial coordinates of the gather. Headers to extract coordinates from are determined
         automatically by the `indexed_by` attribute of the gather. `None` if the gather is indexed by unsupported
         headers or required coords headers were not loaded or coordinates are non-unique for traces of the gather."""
-        try:
-            coords_cols = get_coords_cols(self.indexed_by)  # Possibly unknown coordinates for indexed_by
-            coords = self[coords_cols]  # Required coords headers may not be loaded
+        try:  # Possibly unknown coordinates for indexed_by, required coords headers may be not loaded
+            coords_cols = get_coords_cols(self.indexed_by, self.survey.source_id_cols, self.survey.receiver_id_cols)
+            coords = self[coords_cols]
         except KeyError:
             return None
         if (coords != coords[0]).any():  # Non-unique coordinates

--- a/seismicpro/gather/gather.py
+++ b/seismicpro/gather/gather.py
@@ -19,8 +19,8 @@ from .cropped_gather import CroppedGather
 from .plot_corrections import NMOCorrectionPlot, LMOCorrectionPlot
 from .utils import correction, normalization, gain
 from .utils import convert_times_to_mask, convert_mask_to_pick, times_to_indices, mute_gather, make_origins
-from ..utils import (to_list, get_coords_cols, set_ticks, format_subplot_yticklabels, set_text_formatting,
-                     add_colorbar, piecewise_polynomial, Coordinates)
+from ..utils import (to_list, get_coords_cols, get_first_defined, set_ticks, format_subplot_yticklabels,
+                     set_text_formatting, add_colorbar, piecewise_polynomial, Coordinates)
 from ..containers import TraceContainer, SamplesContainer
 from ..muter import Muter, MuterField
 from ..velocity_spectrum import VerticalVelocitySpectrum, ResidualVelocitySpectrum
@@ -208,10 +208,6 @@ class Gather(TraceContainer, SamplesContainer):
         offsets = self.headers.get('offset')
         offset_range = f'[{np.min(offsets)} m, {np.max(offsets)} m]' if offsets is not None else None
 
-        # Format gather coordinates
-        coords = self.coords
-        coords_str = "Unknown" if coords is None else str(coords)
-
         # Count the number of zero/constant traces
         n_dead_traces = np.isclose(np.max(self.data, axis=1), np.min(self.data, axis=1)).sum()
 
@@ -221,7 +217,7 @@ class Gather(TraceContainer, SamplesContainer):
 
         Indexed by:                  {', '.join(to_list(self.indexed_by))}
         Index value:                 {'Combined' if self.index is None else self.index}
-        Gather coordinates:          {coords_str}
+        Gather coordinates:          {get_first_defined(self.coords, "Unknown")}
         Gather sorting:              {self.sort_by}
 
         Number of traces:            {self.n_traces}

--- a/seismicpro/index.py
+++ b/seismicpro/index.py
@@ -366,20 +366,20 @@ class SeismicIndex(DatasetIndex):
         if self.is_empty:
             return "Empty index"
 
-        info_df = pd.DataFrame({"Gathers": self.n_gathers_by_part, "Traces": self.n_traces_by_part},
+        fold = (np.array(self.n_traces_by_part) / np.array(self.n_gathers_by_part)).astype(np.int32)
+        info_df = pd.DataFrame({"Traces": self.n_traces_by_part, "Gathers": self.n_gathers_by_part, "Fold": fold},
                                index=pd.RangeIndex(self.n_parts, name="Part"))
         for sur in self.survey_names:
             info_df[f"Survey {sur}"] = [os.path.basename(part.surveys_dict[sur].path) for part in self.parts]
 
         msg = f"""
-        {index_path} info:
-
         Indexed by:                {", ".join(to_list(self.indexed_by))}
-        Number of gathers:         {self.n_gathers}
         Number of traces:          {self.n_traces}
+        Number of gathers:         {self.n_gathers}
+        Mean gather fold:          {int(self.n_traces / self.n_gathers)}
         Is split:                  {self.is_split}
 
-        Index parts info:
+        Statistics of {index_path} parts:
         """
         msg = indent(dedent(msg) + info_df.to_string() + "\n", " " * indent_size)
 

--- a/seismicpro/refractor_velocity/refractor_velocity_field.py
+++ b/seismicpro/refractor_velocity/refractor_velocity_field.py
@@ -267,7 +267,7 @@ class RefractorVelocityField(SpatialField):
             raise ValueError("Survey must be indexed by gathers, not individual traces")
 
         # Extract required headers from the survey
-        coords_cols = get_coords_cols(survey.indexed_by)
+        coords_cols = get_coords_cols(survey.indexed_by, survey.source_id_cols, survey.receiver_id_cols)
         survey_coords = survey[coords_cols]
         survey_offsets = survey["offset"]
         survey_times = survey[first_breaks_col]

--- a/seismicpro/survey/headers.py
+++ b/seismicpro/survey/headers.py
@@ -2,8 +2,6 @@
 
 import os
 import mmap
-import warnings
-from textwrap import wrap
 from struct import unpack
 from functools import partial
 from concurrent.futures import ProcessPoolExecutor
@@ -12,7 +10,6 @@ import segyio
 import numpy as np
 import pandas as pd
 from tqdm.auto import tqdm
-from sklearn.neighbors import RadiusNeighborsRegressor
 
 from ..const import TRACE_HEADER_SIZE, ENDIANNESS
 from ..utils import ForPoolExecutor
@@ -98,105 +95,3 @@ def load_headers(path, headers_to_load, trace_data_offset, trace_size, n_traces,
                 future.add_done_callback(partial(callback, start_pos=start))
 
     return pd.DataFrame(headers, columns=headers_order)
-
-
-# pylint: disable=too-many-statements
-def validate_headers(headers, offset_atol=10, cdp_atol=10, elev_atol=5, elev_radius=50):
-    """Validate trace headers for consistency"""
-    msg_list = []
-
-    shot_cols = ["SourceX", "SourceY"]
-    rec_cols = ["GroupX", "GroupY"]
-    cdp_cols = ["CDP_X", "CDP_Y"]
-    bin_cols = ["INLINE_3D", "CROSSLINE_3D"]
-
-    headers = headers.copy(deep=False)
-    headers.reset_index(inplace=True)
-
-    loaded_columns = set(headers.columns)
-    available_columns = set(headers.columns[headers.any(axis=0)])
-
-    zero_columns = loaded_columns - available_columns
-    if zero_columns:
-        msg_list.append("Empty headers: " + ", ".join(zero_columns))
-
-    if {"FieldRecord", "TraceNumber"} <= available_columns:
-        if headers.duplicated(["FieldRecord", "TraceNumber"]).any():
-            msg_list.append("Non-unique traces identifier (FieldRecord, TraceNumber)")
-
-    if {"FieldRecord", *shot_cols} <= available_columns:
-        fr_with_coords = headers[["FieldRecord", *shot_cols]].drop_duplicates()
-        if fr_with_coords.duplicated('FieldRecord').any() or fr_with_coords.duplicated(shot_cols).any():
-            msg_list.append("Non-unique mapping of source coordinates (SourceX, SourceY) and source ID (FieldRecord)")
-
-    if "SourceUpholeTime" in available_columns:
-        if (headers["SourceUpholeTime"] < 0).any():
-            msg_list.append("Negative uphole times")
-
-    if "SourceDepth" in available_columns:
-        if (headers["SourceDepth"] < 0).any():
-            msg_list.append("Negative uphole depths")
-
-    if {"SourceUpholeTime", "SourceDepth"} <= loaded_columns:
-        zero_time_mask = np.isclose(headers["SourceUpholeTime"], 0)
-        zero_depth_mask = np.isclose(headers["SourceDepth"], 0)
-        if (~zero_time_mask[zero_depth_mask]).any():
-            msg_list.append("Non-zero uphole time for zero uphole depth")
-        if (~zero_depth_mask[zero_time_mask]).any():
-            msg_list.append("Non-zero uphole depth for zero uphole time")
-
-    if 'offset' in available_columns:
-        if (headers['offset'] < 0).any():
-            msg_list.append("Signed offsets")
-
-    if {*shot_cols, *rec_cols, "offset"} <= available_columns:
-        calculated_offsets = np.sqrt(np.sum((headers[shot_cols].values - headers[rec_cols].values)**2, axis=1))
-        if not np.allclose(calculated_offsets, headers["offset"].abs(), rtol=0, atol=offset_atol):
-            msg_list.append("Offsets in headers and calculated distances between shots (SourceX, SourceY) and "
-                            "receivers (GroupX, GroupY) do not match for some traces within margin of error equal to "
-                            f"{offset_atol} meters")
-
-    if {*cdp_cols, *bin_cols} <= available_columns:
-        unique_bins_cdp = headers[[*bin_cols, *cdp_cols]].drop_duplicates()
-        if unique_bins_cdp.duplicated(cdp_cols).any() or unique_bins_cdp.duplicated(bin_cols).any():
-            msg_list.append("Non-unique mapping of midpoint (CDP_X, CDP_Y) to line-based (INLINE_3D/ CROSSLINE_3D) "
-                            "coordinates")
-
-    if {*shot_cols, *rec_cols, *cdp_cols} <= available_columns:
-        calculated_cdp = (headers[shot_cols].values + headers[rec_cols].values) / 2
-        if not np.allclose(calculated_cdp, headers[cdp_cols], rtol=0, atol=cdp_atol):
-            msg_list.append("CDP_X and CDP_Y coordinates in headers and those calculated as midpoint between shots "
-                            "(SourceX, SourceY) and receivers (GroupX, GroupY) do not match for some traces within "
-                            f"margin of error equal to {cdp_atol} meters")
-
-    if {*shot_cols, "SourceSurfaceElevation"} <= available_columns:
-        unique_shot_elevs = headers[[*shot_cols, "SourceSurfaceElevation"]].drop_duplicates()
-        has_nonunique_shot_elevs = unique_shot_elevs.duplicated(shot_cols).any()
-        if has_nonunique_shot_elevs:
-            msg_list.append("Non-unique surface elevation (SourceSurfaceElevation) for at least one shot")
-
-    if {*rec_cols, "ReceiverGroupElevation"} <= available_columns:
-        unique_rec_elevs = headers[[*rec_cols, "ReceiverGroupElevation"]].drop_duplicates()
-        has_nonunique_rec_elevs = unique_rec_elevs.duplicated(rec_cols).any()
-        if has_nonunique_rec_elevs:
-            msg_list.append("Non-unique surface elevation (ReceiverGroupElevation) for at least one receiver")
-
-    if {*shot_cols, *rec_cols, "ReceiverGroupElevation", "SourceSurfaceElevation"} <= available_columns:
-        if has_nonunique_shot_elevs:
-            unique_shot_elevs = unique_shot_elevs[~unique_shot_elevs[shot_cols].duplicated(keep=False)]
-        if has_nonunique_rec_elevs:
-            unique_rec_elevs = unique_rec_elevs[~unique_rec_elevs[rec_cols].duplicated(keep=False)]
-
-        if len(unique_shot_elevs) > 0 and len(unique_rec_elevs) > 0:
-            data = np.concatenate((unique_shot_elevs.to_numpy(), unique_rec_elevs.to_numpy()))
-            rnr = RadiusNeighborsRegressor(radius=elev_radius).fit(data[:, :2], data[:, 2])
-            if not np.allclose(rnr.predict(data[:, :2]), data[:, 2], rtol=0, atol=elev_atol):
-                msg_list.append("Elevations of shot (SourceSurfaceElevation) and receiver (ReceiverGroupElevation) "
-                                f"differ by more than {elev_atol} meters within radius of {elev_radius} meters")
-
-    if msg_list:
-        line_sep = "\n\n" + "-"*80
-        msg_list = ["\n    ".join(wrap(msg, width=76)) for msg in msg_list]
-        warning_msg = line_sep + "\n\nThe loaded Survey has the following problems with trace headers:"
-        warning_msg += "".join([f"\n\n {i+1}. {msg}" for i, msg in enumerate(msg_list)]) + line_sep
-        warnings.warn(warning_msg)

--- a/seismicpro/survey/headers_checks.py
+++ b/seismicpro/survey/headers_checks.py
@@ -15,7 +15,7 @@ def warn_list(title, warning_list, width=80):
     if n_warnings == 0:
         return
     ix_len = len(str(n_warnings))
-    wrap_space = (3 + ix_len)
+    wrap_space = 3 + ix_len
     wrap_sep = "\n" + " " * wrap_space
     line_sep = "\n\n" + "-" * width
     warning_list = [wrap_sep.join(wrap(warn_str, width=width-wrap_space)) for warn_str in warning_list]

--- a/seismicpro/survey/headers_checks.py
+++ b/seismicpro/survey/headers_checks.py
@@ -48,19 +48,19 @@ def validate_trace_headers(headers, offset_atol=10, cdp_atol=10, elevation_atol=
         n_duplicated = headers.duplicated(["FieldRecord", "TraceNumber"], keep=False).sum()
         if n_duplicated:
             msg_list.append(f"Non-unique traces identifier (FieldRecord, TraceNumber) for {n_duplicated} traces "
-                            f"({(n_duplicated / n_traces):.02f} %)")
+                            f"({(n_duplicated / n_traces):.02f}%)")
 
     if "SourceUpholeTime" in non_empty_columns:
         n_neg_uphole_time = (headers["SourceUpholeTime"] < 0).sum()
         if n_neg_uphole_time:
             msg_list.append(f"Negative uphole times for {n_neg_uphole_time} traces "
-                            f"({(n_neg_uphole_time / n_traces):.02f} %)")
+                            f"({(n_neg_uphole_time / n_traces):.02f}%)")
 
     if "SourceDepth" in non_empty_columns:
         n_neg_uphole_depth = (headers["SourceUpholeTime"] < 0).sum()
         if n_neg_uphole_depth:
             msg_list.append(f"Negative uphole depths for {n_neg_uphole_depth} traces "
-                            f"({(n_neg_uphole_depth / n_traces):.02f} %)")
+                            f"({(n_neg_uphole_depth / n_traces):.02f}%)")
 
     if {"SourceUpholeTime", "SourceDepth"} <= loaded_columns:
         zero_time_mask = np.isclose(headers["SourceUpholeTime"], 0)
@@ -69,15 +69,15 @@ def validate_trace_headers(headers, offset_atol=10, cdp_atol=10, elevation_atol=
         n_zero_depth = (zero_depth_mask[~zero_time_mask]).sum()
         if n_zero_time:
             msg_list.append(f"Zero uphole time for non-zero uphole depth for {n_zero_time} traces "
-                            f"({(n_zero_time / n_traces):.02f} %)")
+                            f"({(n_zero_time / n_traces):.02f}%)")
         if n_zero_depth:
             msg_list.append(f"Zero uphole depth for non-zero uphole time for {n_zero_depth} traces "
-                            f"({(n_zero_depth / n_traces):.02f} %)")
+                            f"({(n_zero_depth / n_traces):.02f}%)")
 
     if "offset" in non_empty_columns:
         n_neg_offsets = (headers["offset"] < 0).sum()
         if n_neg_offsets:
-            msg_list.append(f"Negative offsets for {n_neg_offsets} traces ({(n_neg_offsets / n_traces):.02f} %)")
+            msg_list.append(f"Negative offsets for {n_neg_offsets} traces ({(n_neg_offsets / n_traces):.02f}%)")
 
     if {*shot_coords_cols, *rec_coords_cols, "offset"} <= non_empty_columns:
         shot_coords = headers[shot_coords_cols].to_numpy()
@@ -88,7 +88,7 @@ def validate_trace_headers(headers, offset_atol=10, cdp_atol=10, elevation_atol=
         if n_diff:
             msg_list.append("Distance between source (SourceX, SourceY) and receiver (GroupX, GroupY) differs from "
                             f"the corresponding offset by more than {offset_atol} meters for {n_diff} traces "
-                            f"({(n_diff / n_traces):.02f} %)")
+                            f"({(n_diff / n_traces):.02f}%)")
 
     if {*shot_coords_cols, *rec_coords_cols, *cdp_coords_cols} <= non_empty_columns:
         calculated_cdp = (headers[shot_coords_cols].to_numpy() + headers[rec_coords_cols].to_numpy()) / 2
@@ -97,7 +97,7 @@ def validate_trace_headers(headers, offset_atol=10, cdp_atol=10, elevation_atol=
         if n_diff:
             msg_list.append("A midpoint between source (SourceX, SourceY) and receiver (GroupX, GroupY) differs from "
                             f"the corresponding coordinates (CDP_X, CDP_Y) by more than {cdp_atol} meters for "
-                            f"{n_diff} traces ({(n_diff / n_traces):.02f} %)")
+                            f"{n_diff} traces ({(n_diff / n_traces):.02f}%)")
 
     if {*shot_coords_cols, "SourceSurfaceElevation"} <= non_empty_columns:
         unique_shot_elevations = headers[shot_coords_cols + ["SourceSurfaceElevation"]].drop_duplicates()
@@ -105,7 +105,7 @@ def validate_trace_headers(headers, offset_atol=10, cdp_atol=10, elevation_atol=
         n_duplicated = (n_uniques > 1).sum()
         if n_duplicated:
             msg_list.append(f"Non-unique surface elevation (SourceSurfaceElevation) for {n_duplicated} source "
-                            f"locations ({(n_duplicated / len(n_uniques)):.02f} %)")
+                            f"locations ({(n_duplicated / len(n_uniques)):.02f}%)")
 
     if {*rec_coords_cols, "ReceiverGroupElevation"} <= non_empty_columns:
         unique_rec_elevations = headers[rec_coords_cols + ["ReceiverGroupElevation"]].drop_duplicates()
@@ -113,7 +113,7 @@ def validate_trace_headers(headers, offset_atol=10, cdp_atol=10, elevation_atol=
         n_duplicated = (n_uniques > 1).sum()
         if n_duplicated:
             msg_list.append(f"Non-unique surface elevation (ReceiverGroupElevation) for {n_duplicated} receiver "
-                            f"locations ({(n_duplicated / len(n_uniques)):.02f} %)")
+                            f"locations ({(n_duplicated / len(n_uniques)):.02f}%)")
 
     if {*shot_coords_cols, *rec_coords_cols, "ReceiverGroupElevation", "SourceSurfaceElevation"} <= non_empty_columns:
         elevations = np.concatenate([unique_shot_elevations.to_numpy(), unique_rec_elevations.to_numpy()])
@@ -124,7 +124,7 @@ def validate_trace_headers(headers, offset_atol=10, cdp_atol=10, elevation_atol=
             msg_list.append("Surface elevations of sources (SourceSurfaceElevation) and receivers "
                             f"(ReceiverGroupElevation) differ by more than {elevation_atol} meters within spatial "
                             f"radius of {elevation_radius} meters for {n_diff} sensor locations "
-                            f"({(n_diff / len(elevations)):.02f} %)")
+                            f"({(n_diff / len(elevations)):.02f}%)")
 
     if {*cdp_coords_cols, *bin_coords_cols} <= non_empty_columns:
         unique_cdp_bin = headers[cdp_coords_cols + bin_coords_cols].drop_duplicates()
@@ -132,14 +132,14 @@ def validate_trace_headers(headers, offset_atol=10, cdp_atol=10, elevation_atol=
         n_duplicated = (n_cdp_per_bin > 1).sum()
         if n_duplicated:
             msg_list.append(f"Non-unique midpoint coordinates (CDP_X, CDP_Y) for {n_duplicated} bins "
-                            f"({(n_duplicated / len(n_cdp_per_bin)):.02f} %)")
+                            f"({(n_duplicated / len(n_cdp_per_bin)):.02f}%)")
         n_bin_per_cdp = unique_cdp_bin.groupby(cdp_coords_cols).size()
         n_duplicated = (n_bin_per_cdp > 1).sum()
         if n_duplicated:
             msg_list.append(f"Non-unique bin (INLINE_3D, CROSSLINE_3D) for {n_duplicated} midpoint locations "
-                            f"({(n_duplicated / len(n_bin_per_cdp)):.02f} %)")
+                            f"({(n_duplicated / len(n_bin_per_cdp)):.02f}%)")
 
-    warn_list("The loaded Survey has the following problems with trace headers:", msg_list)
+    warn_list("The survey has the following inconsistencies in trace headers:", msg_list)
 
 
 def validate_source_headers(headers, source_id_cols=None):
@@ -161,13 +161,13 @@ def validate_source_headers(headers, source_id_cols=None):
     coords_cols = ["SourceX", "SourceY"]
     loaded_columns = set(headers.columns)
 
-    if {*source_id_cols, *coords_cols} <= loaded_columns:
+    if set(source_id_cols) != set(coords_cols) and {*source_id_cols, *coords_cols} <= loaded_columns:
         unique_coords = headers[source_id_cols + coords_cols].drop_duplicates()
         n_uniques = unique_coords.groupby(source_id_cols).size()
         n_duplicated = (n_uniques > 1).sum()
         if n_duplicated:
             msg_list.append(f"Non-unique source coordinates (SourceX, SourceY) for {n_duplicated} sources "
-                            f"({(n_duplicated / len(n_uniques)):.02f} %)")
+                            f"({(n_duplicated / len(n_uniques)):.02f}%)")
 
     if {*source_id_cols, "SourceSurfaceElevation"} <= loaded_columns:
         unique_elevations = headers[source_id_cols + ["SourceSurfaceElevation"]].drop_duplicates()
@@ -175,7 +175,7 @@ def validate_source_headers(headers, source_id_cols=None):
         n_duplicated = (n_uniques > 1).sum()
         if n_duplicated:
             msg_list.append(f"Non-unique surface elevation (SourceSurfaceElevation) for {n_duplicated} sources "
-                            f"({(n_duplicated / len(n_uniques)):.02f} %)")
+                            f"({(n_duplicated / len(n_uniques)):.02f}%)")
 
     if {*source_id_cols, "SourceUpholeTime"} <= loaded_columns:
         unique_uphole_time = headers[source_id_cols + ["SourceUpholeTime"]].drop_duplicates()
@@ -183,7 +183,7 @@ def validate_source_headers(headers, source_id_cols=None):
         n_duplicated = (n_uniques > 1).sum()
         if n_duplicated:
             msg_list.append(f"Non-unique source uphole time (SourceUpholeTime) for {n_duplicated} sources "
-                            f"({(n_duplicated / len(n_uniques)):.02f} %)")
+                            f"({(n_duplicated / len(n_uniques)):.02f}%)")
 
     if {*source_id_cols, "SourceDepth"} <= loaded_columns:
         unique_depth = headers[source_id_cols + ["SourceDepth"]].drop_duplicates()
@@ -191,7 +191,7 @@ def validate_source_headers(headers, source_id_cols=None):
         n_duplicated = (n_uniques > 1).sum()
         if n_duplicated:
             msg_list.append(f"Non-unique source depth (SourceDepth) for {n_duplicated} sources "
-                            f"({(n_duplicated / len(n_uniques)):.02f} %)")
+                            f"({(n_duplicated / len(n_uniques)):.02f}%)")
 
     warn_list("Selected source ID columns result in the following inconsistencies of trace headers:", msg_list)
 
@@ -216,13 +216,13 @@ def validate_receiver_headers(headers, receiver_id_cols=None):
     coords_cols = ["GroupX", "GroupY"]
     loaded_columns = set(headers.columns)
 
-    if {*receiver_id_cols, *coords_cols} <= loaded_columns:
+    if set(receiver_id_cols) != set(coords_cols) and {*receiver_id_cols, *coords_cols} <= loaded_columns:
         unique_coords = headers[receiver_id_cols + coords_cols].drop_duplicates()
         n_uniques = unique_coords.groupby(receiver_id_cols).size()
         n_duplicated = (n_uniques > 1).sum()
         if n_duplicated:
             msg_list.append(f"Non-unique receiver coordinates (GroupX, GroupY) for {n_duplicated} receivers "
-                            f"({(n_duplicated / len(n_uniques)):.02f} %)")
+                            f"({(n_duplicated / len(n_uniques)):.02f}%)")
 
     if {*receiver_id_cols, "ReceiverGroupElevation"} <= loaded_columns:
         unique_elevations = headers[receiver_id_cols + ["ReceiverGroupElevation"]].drop_duplicates()
@@ -230,6 +230,6 @@ def validate_receiver_headers(headers, receiver_id_cols=None):
         n_duplicated = (n_uniques > 1).sum()
         if n_duplicated:
             msg_list.append(f"Non-unique surface elevation (ReceiverGroupElevation) for {n_duplicated} receivers "
-                            f"({(n_duplicated / len(n_uniques)):.02f} %)")
+                            f"({(n_duplicated / len(n_uniques)):.02f}%)")
 
     warn_list("Selected receiver ID columns result in the following inconsistencies of trace headers:", msg_list)

--- a/seismicpro/survey/headers_checks.py
+++ b/seismicpro/survey/headers_checks.py
@@ -48,19 +48,19 @@ def validate_trace_headers(headers, offset_atol=10, cdp_atol=10, elevation_atol=
         n_duplicated = headers.duplicated(["FieldRecord", "TraceNumber"], keep=False).sum()
         if n_duplicated:
             msg_list.append(f"Non-unique traces identifier (FieldRecord, TraceNumber) for {n_duplicated} traces "
-                            f"({(n_duplicated / n_traces):.02f}%)")
+                            f"({(n_duplicated / n_traces):.2%})")
 
     if "SourceUpholeTime" in non_empty_columns:
         n_neg_uphole_time = (headers["SourceUpholeTime"] < 0).sum()
         if n_neg_uphole_time:
             msg_list.append(f"Negative uphole times for {n_neg_uphole_time} traces "
-                            f"({(n_neg_uphole_time / n_traces):.02f}%)")
+                            f"({(n_neg_uphole_time / n_traces):.2%})")
 
     if "SourceDepth" in non_empty_columns:
         n_neg_uphole_depth = (headers["SourceUpholeTime"] < 0).sum()
         if n_neg_uphole_depth:
             msg_list.append(f"Negative uphole depths for {n_neg_uphole_depth} traces "
-                            f"({(n_neg_uphole_depth / n_traces):.02f}%)")
+                            f"({(n_neg_uphole_depth / n_traces):.2%})")
 
     if {"SourceUpholeTime", "SourceDepth"} <= loaded_columns:
         zero_time_mask = np.isclose(headers["SourceUpholeTime"], 0)
@@ -69,15 +69,15 @@ def validate_trace_headers(headers, offset_atol=10, cdp_atol=10, elevation_atol=
         n_zero_depth = (zero_depth_mask[~zero_time_mask]).sum()
         if n_zero_time:
             msg_list.append(f"Zero uphole time for non-zero uphole depth for {n_zero_time} traces "
-                            f"({(n_zero_time / n_traces):.02f}%)")
+                            f"({(n_zero_time / n_traces):.2%})")
         if n_zero_depth:
             msg_list.append(f"Zero uphole depth for non-zero uphole time for {n_zero_depth} traces "
-                            f"({(n_zero_depth / n_traces):.02f}%)")
+                            f"({(n_zero_depth / n_traces):.2%})")
 
     if "offset" in non_empty_columns:
         n_neg_offsets = (headers["offset"] < 0).sum()
         if n_neg_offsets:
-            msg_list.append(f"Negative offsets for {n_neg_offsets} traces ({(n_neg_offsets / n_traces):.02f}%)")
+            msg_list.append(f"Negative offsets for {n_neg_offsets} traces ({(n_neg_offsets / n_traces):.2%})")
 
     if {*shot_coords_cols, *rec_coords_cols, "offset"} <= non_empty_columns:
         shot_coords = headers[shot_coords_cols].to_numpy()
@@ -88,7 +88,7 @@ def validate_trace_headers(headers, offset_atol=10, cdp_atol=10, elevation_atol=
         if n_diff:
             msg_list.append("Distance between source (SourceX, SourceY) and receiver (GroupX, GroupY) differs from "
                             f"the corresponding offset by more than {offset_atol} meters for {n_diff} traces "
-                            f"({(n_diff / n_traces):.02f}%)")
+                            f"({(n_diff / n_traces):.2%})")
 
     if {*shot_coords_cols, *rec_coords_cols, *cdp_coords_cols} <= non_empty_columns:
         calculated_cdp = (headers[shot_coords_cols].to_numpy() + headers[rec_coords_cols].to_numpy()) / 2
@@ -97,7 +97,7 @@ def validate_trace_headers(headers, offset_atol=10, cdp_atol=10, elevation_atol=
         if n_diff:
             msg_list.append("A midpoint between source (SourceX, SourceY) and receiver (GroupX, GroupY) differs from "
                             f"the corresponding coordinates (CDP_X, CDP_Y) by more than {cdp_atol} meters for "
-                            f"{n_diff} traces ({(n_diff / n_traces):.02f}%)")
+                            f"{n_diff} traces ({(n_diff / n_traces):.2%})")
 
     if {*shot_coords_cols, "SourceSurfaceElevation"} <= non_empty_columns:
         unique_shot_elevations = headers[shot_coords_cols + ["SourceSurfaceElevation"]].drop_duplicates()
@@ -105,7 +105,7 @@ def validate_trace_headers(headers, offset_atol=10, cdp_atol=10, elevation_atol=
         n_duplicated = (n_uniques > 1).sum()
         if n_duplicated:
             msg_list.append(f"Non-unique surface elevation (SourceSurfaceElevation) for {n_duplicated} source "
-                            f"locations ({(n_duplicated / len(n_uniques)):.02f}%)")
+                            f"locations ({(n_duplicated / len(n_uniques)):.2%})")
 
     if {*rec_coords_cols, "ReceiverGroupElevation"} <= non_empty_columns:
         unique_rec_elevations = headers[rec_coords_cols + ["ReceiverGroupElevation"]].drop_duplicates()
@@ -113,7 +113,7 @@ def validate_trace_headers(headers, offset_atol=10, cdp_atol=10, elevation_atol=
         n_duplicated = (n_uniques > 1).sum()
         if n_duplicated:
             msg_list.append(f"Non-unique surface elevation (ReceiverGroupElevation) for {n_duplicated} receiver "
-                            f"locations ({(n_duplicated / len(n_uniques)):.02f}%)")
+                            f"locations ({(n_duplicated / len(n_uniques)):.2%})")
 
     if {*shot_coords_cols, *rec_coords_cols, "ReceiverGroupElevation", "SourceSurfaceElevation"} <= non_empty_columns:
         elevations = np.concatenate([unique_shot_elevations.to_numpy(), unique_rec_elevations.to_numpy()])
@@ -124,7 +124,7 @@ def validate_trace_headers(headers, offset_atol=10, cdp_atol=10, elevation_atol=
             msg_list.append("Surface elevations of sources (SourceSurfaceElevation) and receivers "
                             f"(ReceiverGroupElevation) differ by more than {elevation_atol} meters within spatial "
                             f"radius of {elevation_radius} meters for {n_diff} sensor locations "
-                            f"({(n_diff / len(elevations)):.02f}%)")
+                            f"({(n_diff / len(elevations)):.2%})")
 
     if {*cdp_coords_cols, *bin_coords_cols} <= non_empty_columns:
         unique_cdp_bin = headers[cdp_coords_cols + bin_coords_cols].drop_duplicates()
@@ -132,12 +132,12 @@ def validate_trace_headers(headers, offset_atol=10, cdp_atol=10, elevation_atol=
         n_duplicated = (n_cdp_per_bin > 1).sum()
         if n_duplicated:
             msg_list.append(f"Non-unique midpoint coordinates (CDP_X, CDP_Y) for {n_duplicated} bins "
-                            f"({(n_duplicated / len(n_cdp_per_bin)):.02f}%)")
+                            f"({(n_duplicated / len(n_cdp_per_bin)):.2%})")
         n_bin_per_cdp = unique_cdp_bin.groupby(cdp_coords_cols).size()
         n_duplicated = (n_bin_per_cdp > 1).sum()
         if n_duplicated:
             msg_list.append(f"Non-unique bin (INLINE_3D, CROSSLINE_3D) for {n_duplicated} midpoint locations "
-                            f"({(n_duplicated / len(n_bin_per_cdp)):.02f}%)")
+                            f"({(n_duplicated / len(n_bin_per_cdp)):.2%})")
 
     warn_list("The survey has the following inconsistencies in trace headers:", msg_list)
 
@@ -167,7 +167,7 @@ def validate_source_headers(headers, source_id_cols=None):
         n_duplicated = (n_uniques > 1).sum()
         if n_duplicated:
             msg_list.append(f"Non-unique source coordinates (SourceX, SourceY) for {n_duplicated} sources "
-                            f"({(n_duplicated / len(n_uniques)):.02f}%)")
+                            f"({(n_duplicated / len(n_uniques)):.2%})")
 
     if {*source_id_cols, "SourceSurfaceElevation"} <= loaded_columns:
         unique_elevations = headers[source_id_cols + ["SourceSurfaceElevation"]].drop_duplicates()
@@ -175,7 +175,7 @@ def validate_source_headers(headers, source_id_cols=None):
         n_duplicated = (n_uniques > 1).sum()
         if n_duplicated:
             msg_list.append(f"Non-unique surface elevation (SourceSurfaceElevation) for {n_duplicated} sources "
-                            f"({(n_duplicated / len(n_uniques)):.02f}%)")
+                            f"({(n_duplicated / len(n_uniques)):.2%})")
 
     if {*source_id_cols, "SourceUpholeTime"} <= loaded_columns:
         unique_uphole_time = headers[source_id_cols + ["SourceUpholeTime"]].drop_duplicates()
@@ -183,7 +183,7 @@ def validate_source_headers(headers, source_id_cols=None):
         n_duplicated = (n_uniques > 1).sum()
         if n_duplicated:
             msg_list.append(f"Non-unique source uphole time (SourceUpholeTime) for {n_duplicated} sources "
-                            f"({(n_duplicated / len(n_uniques)):.02f}%)")
+                            f"({(n_duplicated / len(n_uniques)):.2%})")
 
     if {*source_id_cols, "SourceDepth"} <= loaded_columns:
         unique_depth = headers[source_id_cols + ["SourceDepth"]].drop_duplicates()
@@ -191,7 +191,7 @@ def validate_source_headers(headers, source_id_cols=None):
         n_duplicated = (n_uniques > 1).sum()
         if n_duplicated:
             msg_list.append(f"Non-unique source depth (SourceDepth) for {n_duplicated} sources "
-                            f"({(n_duplicated / len(n_uniques)):.02f}%)")
+                            f"({(n_duplicated / len(n_uniques)):.2%})")
 
     warn_list("Selected source ID columns result in the following inconsistencies of trace headers:", msg_list)
 
@@ -222,7 +222,7 @@ def validate_receiver_headers(headers, receiver_id_cols=None):
         n_duplicated = (n_uniques > 1).sum()
         if n_duplicated:
             msg_list.append(f"Non-unique receiver coordinates (GroupX, GroupY) for {n_duplicated} receivers "
-                            f"({(n_duplicated / len(n_uniques)):.02f}%)")
+                            f"({(n_duplicated / len(n_uniques)):.2%})")
 
     if {*receiver_id_cols, "ReceiverGroupElevation"} <= loaded_columns:
         unique_elevations = headers[receiver_id_cols + ["ReceiverGroupElevation"]].drop_duplicates()
@@ -230,6 +230,6 @@ def validate_receiver_headers(headers, receiver_id_cols=None):
         n_duplicated = (n_uniques > 1).sum()
         if n_duplicated:
             msg_list.append(f"Non-unique surface elevation (ReceiverGroupElevation) for {n_duplicated} receivers "
-                            f"({(n_duplicated / len(n_uniques)):.02f}%)")
+                            f"({(n_duplicated / len(n_uniques)):.2%})")
 
     warn_list("Selected receiver ID columns result in the following inconsistencies of trace headers:", msg_list)

--- a/seismicpro/survey/headers_checks.py
+++ b/seismicpro/survey/headers_checks.py
@@ -1,0 +1,235 @@
+"""Contains methods to validate trace headers for consistency"""
+
+import warnings
+from textwrap import wrap
+
+import numpy as np
+from sklearn.neighbors import RadiusNeighborsRegressor
+
+from ..utils import to_list
+
+
+def warn_list(title, warning_list, width=80):
+    """Warn about several issues listed in `warning_list`."""
+    n_warnings = len(warning_list)
+    if n_warnings == 0:
+        return
+    ix_len = len(str(n_warnings))
+    wrap_space = (3 + ix_len)
+    wrap_sep = "\n" + " " * wrap_space
+    line_sep = "\n\n" + "-" * width
+    warning_list = [wrap_sep.join(wrap(warn_str, width=width-wrap_space)) for warn_str in warning_list]
+    warning_msg = line_sep + "\n\n" + "\n".join(wrap(title, width=width))
+    warning_msg += "".join([f"\n\n {i+1:{ix_len}d}. {warn_str}" for i, warn_str in enumerate(warning_list)]) + line_sep
+    warnings.warn(warning_msg)
+
+
+# pylint: disable-next=too-many-statements
+def validate_trace_headers(headers, offset_atol=10, cdp_atol=10, elevation_atol=5, elevation_radius=50):
+    """Validate trace headers for consistency. `headers` `DataFrame` is expected to have reset index."""
+    n_traces = len(headers)
+    if n_traces == 0:
+        return
+
+    msg_list = []
+
+    shot_coords_cols = ["SourceX", "SourceY"]
+    rec_coords_cols = ["GroupX", "GroupY"]
+    cdp_coords_cols = ["CDP_X", "CDP_Y"]
+    bin_coords_cols = ["INLINE_3D", "CROSSLINE_3D"]
+
+    loaded_columns = set(headers.columns)
+    non_empty_columns = set(headers.columns[headers.any(axis=0)])
+    empty_columns = loaded_columns - non_empty_columns
+    if empty_columns:
+        msg_list.append("Empty headers: " + ", ".join(empty_columns))
+
+    if {"FieldRecord", "TraceNumber"} <= non_empty_columns:
+        n_duplicated = headers.duplicated(["FieldRecord", "TraceNumber"], keep=False).sum()
+        if n_duplicated:
+            msg_list.append(f"Non-unique traces identifier (FieldRecord, TraceNumber) for {n_duplicated} traces "
+                            f"({(n_duplicated / n_traces):.02f} %)")
+
+    if "SourceUpholeTime" in non_empty_columns:
+        n_neg_uphole_time = (headers["SourceUpholeTime"] < 0).sum()
+        if n_neg_uphole_time:
+            msg_list.append(f"Negative uphole times for {n_neg_uphole_time} traces "
+                            f"({(n_neg_uphole_time / n_traces):.02f} %)")
+
+    if "SourceDepth" in non_empty_columns:
+        n_neg_uphole_depth = (headers["SourceUpholeTime"] < 0).sum()
+        if n_neg_uphole_depth:
+            msg_list.append(f"Negative uphole depths for {n_neg_uphole_depth} traces "
+                            f"({(n_neg_uphole_depth / n_traces):.02f} %)")
+
+    if {"SourceUpholeTime", "SourceDepth"} <= loaded_columns:
+        zero_time_mask = np.isclose(headers["SourceUpholeTime"], 0)
+        zero_depth_mask = np.isclose(headers["SourceDepth"], 0)
+        n_zero_time = (zero_time_mask[~zero_depth_mask]).sum()
+        n_zero_depth = (zero_depth_mask[~zero_time_mask]).sum()
+        if n_zero_time:
+            msg_list.append(f"Zero uphole time for non-zero uphole depth for {n_zero_time} traces "
+                            f"({(n_zero_time / n_traces):.02f} %)")
+        if n_zero_depth:
+            msg_list.append(f"Zero uphole depth for non-zero uphole time for {n_zero_depth} traces "
+                            f"({(n_zero_depth / n_traces):.02f} %)")
+
+    if "offset" in non_empty_columns:
+        n_neg_offsets = (headers["offset"] < 0).sum()
+        if n_neg_offsets:
+            msg_list.append(f"Negative offsets for {n_neg_offsets} traces ({(n_neg_offsets / n_traces):.02f} %)")
+
+    if {*shot_coords_cols, *rec_coords_cols, "offset"} <= non_empty_columns:
+        shot_coords = headers[shot_coords_cols].to_numpy()
+        rec_coords = headers[rec_coords_cols].to_numpy()
+        calculated_offsets = np.sqrt(np.sum((shot_coords - rec_coords)**2, axis=1))
+        close_mask = np.isclose(calculated_offsets, headers["offset"].abs(), rtol=0, atol=offset_atol)
+        n_diff = (~close_mask).sum()
+        if n_diff:
+            msg_list.append("Distance between source (SourceX, SourceY) and receiver (GroupX, GroupY) differs from "
+                            f"the corresponding offset by more than {offset_atol} meters for {n_diff} traces "
+                            f"({(n_diff / n_traces):.02f} %)")
+
+    if {*shot_coords_cols, *rec_coords_cols, *cdp_coords_cols} <= non_empty_columns:
+        calculated_cdp = (headers[shot_coords_cols].to_numpy() + headers[rec_coords_cols].to_numpy()) / 2
+        close_mask = np.sqrt(np.sum((calculated_cdp - headers[cdp_coords_cols])**2, axis=1)) <= cdp_atol
+        n_diff = (~close_mask).sum()
+        if n_diff:
+            msg_list.append("A midpoint between source (SourceX, SourceY) and receiver (GroupX, GroupY) differs from "
+                            f"the corresponding coordinates (CDP_X, CDP_Y) by more than {cdp_atol} meters for "
+                            f"{n_diff} traces ({(n_diff / n_traces):.02f} %)")
+
+    if {*shot_coords_cols, "SourceSurfaceElevation"} <= non_empty_columns:
+        unique_shot_elevations = headers[shot_coords_cols + ["SourceSurfaceElevation"]].drop_duplicates()
+        n_uniques = unique_shot_elevations.groupby(shot_coords_cols).size()
+        n_duplicated = (n_uniques > 1).sum()
+        if n_duplicated:
+            msg_list.append(f"Non-unique surface elevation (SourceSurfaceElevation) for {n_duplicated} source "
+                            f"locations ({(n_duplicated / len(n_uniques)):.02f} %)")
+
+    if {*rec_coords_cols, "ReceiverGroupElevation"} <= non_empty_columns:
+        unique_rec_elevations = headers[rec_coords_cols + ["ReceiverGroupElevation"]].drop_duplicates()
+        n_uniques = unique_rec_elevations.groupby(rec_coords_cols).size()
+        n_duplicated = (n_uniques > 1).sum()
+        if n_duplicated:
+            msg_list.append(f"Non-unique surface elevation (ReceiverGroupElevation) for {n_duplicated} receiver "
+                            f"locations ({(n_duplicated / len(n_uniques)):.02f} %)")
+
+    if {*shot_coords_cols, *rec_coords_cols, "ReceiverGroupElevation", "SourceSurfaceElevation"} <= non_empty_columns:
+        elevations = np.concatenate([unique_shot_elevations.to_numpy(), unique_rec_elevations.to_numpy()])
+        rnr = RadiusNeighborsRegressor(radius=elevation_radius).fit(elevations[:, :2], elevations[:, 2])
+        close_mask = np.isclose(rnr.predict(elevations[:, :2]), elevations[:, 2], rtol=0, atol=elevation_atol)
+        n_diff = (~close_mask).sum()
+        if n_diff:
+            msg_list.append("Surface elevations of sources (SourceSurfaceElevation) and receivers "
+                            f"(ReceiverGroupElevation) differ by more than {elevation_atol} meters within spatial "
+                            f"radius of {elevation_radius} meters for {n_diff} sensor locations "
+                            f"({(n_diff / len(elevations)):.02f} %)")
+
+    if {*cdp_coords_cols, *bin_coords_cols} <= non_empty_columns:
+        unique_cdp_bin = headers[cdp_coords_cols + bin_coords_cols].drop_duplicates()
+        n_cdp_per_bin = unique_cdp_bin.groupby(bin_coords_cols).size()
+        n_duplicated = (n_cdp_per_bin > 1).sum()
+        if n_duplicated:
+            msg_list.append(f"Non-unique midpoint coordinates (CDP_X, CDP_Y) for {n_duplicated} bins "
+                            f"({(n_duplicated / len(n_cdp_per_bin)):.02f} %)")
+        n_bin_per_cdp = unique_cdp_bin.groupby(cdp_coords_cols).size()
+        n_duplicated = (n_bin_per_cdp > 1).sum()
+        if n_duplicated:
+            msg_list.append(f"Non-unique bin (INLINE_3D, CROSSLINE_3D) for {n_duplicated} midpoint locations "
+                            f"({(n_duplicated / len(n_bin_per_cdp)):.02f} %)")
+
+    warn_list("The loaded Survey has the following problems with trace headers:", msg_list)
+
+
+def validate_source_headers(headers, source_id_cols=None):
+    """Validate source-related trace headers for consistency. `headers` `DataFrame` is expected to have reset index."""
+    n_traces = len(headers)
+    if n_traces == 0:
+        return
+
+    if source_id_cols is None:
+        return
+    source_id_cols = to_list(source_id_cols)
+
+    empty_id_mask = (headers[source_id_cols] == 0).all(axis=0)
+    if empty_id_mask.any():
+        empty_id_cols = ", ".join(empty_id_mask[empty_id_mask].index)
+        warnings.warn(f"No checks are performed since the following source ID headers are empty: {empty_id_cols}")
+
+    msg_list = []
+    coords_cols = ["SourceX", "SourceY"]
+    loaded_columns = set(headers.columns)
+
+    if {*source_id_cols, *coords_cols} <= loaded_columns:
+        unique_coords = headers[source_id_cols + coords_cols].drop_duplicates()
+        n_uniques = unique_coords.groupby(source_id_cols).size()
+        n_duplicated = (n_uniques > 1).sum()
+        if n_duplicated:
+            msg_list.append(f"Non-unique source coordinates (SourceX, SourceY) for {n_duplicated} sources "
+                            f"({(n_duplicated / len(n_uniques)):.02f} %)")
+
+    if {*source_id_cols, "SourceSurfaceElevation"} <= loaded_columns:
+        unique_elevations = headers[source_id_cols + ["SourceSurfaceElevation"]].drop_duplicates()
+        n_uniques = unique_elevations.groupby(source_id_cols).size()
+        n_duplicated = (n_uniques > 1).sum()
+        if n_duplicated:
+            msg_list.append(f"Non-unique surface elevation (SourceSurfaceElevation) for {n_duplicated} sources "
+                            f"({(n_duplicated / len(n_uniques)):.02f} %)")
+
+    if {*source_id_cols, "SourceUpholeTime"} <= loaded_columns:
+        unique_uphole_time = headers[source_id_cols + ["SourceUpholeTime"]].drop_duplicates()
+        n_uniques = unique_uphole_time.groupby(source_id_cols).size()
+        n_duplicated = (n_uniques > 1).sum()
+        if n_duplicated:
+            msg_list.append(f"Non-unique source uphole time (SourceUpholeTime) for {n_duplicated} sources "
+                            f"({(n_duplicated / len(n_uniques)):.02f} %)")
+
+    if {*source_id_cols, "SourceDepth"} <= loaded_columns:
+        unique_depth = headers[source_id_cols + ["SourceDepth"]].drop_duplicates()
+        n_uniques = unique_depth.groupby(source_id_cols).size()
+        n_duplicated = (n_uniques > 1).sum()
+        if n_duplicated:
+            msg_list.append(f"Non-unique source depth (SourceDepth) for {n_duplicated} sources "
+                            f"({(n_duplicated / len(n_uniques)):.02f} %)")
+
+    warn_list("Selected source ID columns result in the following inconsistencies of trace headers:", msg_list)
+
+
+def validate_receiver_headers(headers, receiver_id_cols=None):
+    """Validate receiver-related trace headers for consistency. `headers` `DataFrame` is expected to have reset
+    index."""
+    n_traces = len(headers)
+    if n_traces == 0:
+        return
+
+    if receiver_id_cols is None:
+        return
+    receiver_id_cols = to_list(receiver_id_cols)
+
+    empty_id_mask = (headers[receiver_id_cols] == 0).all(axis=0)
+    if empty_id_mask.any():
+        empty_id_cols = ", ".join(empty_id_mask[empty_id_mask].index)
+        warnings.warn(f"No checks are performed since the following receiver ID headers are empty: {empty_id_cols}")
+
+    msg_list = []
+    coords_cols = ["GroupX", "GroupY"]
+    loaded_columns = set(headers.columns)
+
+    if {*receiver_id_cols, *coords_cols} <= loaded_columns:
+        unique_coords = headers[receiver_id_cols + coords_cols].drop_duplicates()
+        n_uniques = unique_coords.groupby(receiver_id_cols).size()
+        n_duplicated = (n_uniques > 1).sum()
+        if n_duplicated:
+            msg_list.append(f"Non-unique receiver coordinates (GroupX, GroupY) for {n_duplicated} receivers "
+                            f"({(n_duplicated / len(n_uniques)):.02f} %)")
+
+    if {*receiver_id_cols, "ReceiverGroupElevation"} <= loaded_columns:
+        unique_elevations = headers[receiver_id_cols + ["ReceiverGroupElevation"]].drop_duplicates()
+        n_uniques = unique_elevations.groupby(receiver_id_cols).size()
+        n_duplicated = (n_uniques > 1).sum()
+        if n_duplicated:
+            msg_list.append(f"Non-unique surface elevation (ReceiverGroupElevation) for {n_duplicated} receivers "
+                            f"({(n_duplicated / len(n_uniques)):.02f} %)")
+
+    warn_list("Selected receiver ID columns result in the following inconsistencies of trace headers:", msg_list)

--- a/seismicpro/survey/metrics.py
+++ b/seismicpro/survey/metrics.py
@@ -6,8 +6,8 @@ from ..metrics import Metric
 
 
 class SurveyAttribute(Metric):
-    """A utility metric class that reindexes given survey by `coords_cols` and allows for plotting gathers by their
-    coordinates. Does not implement any calculation logic."""
+    """A utility metric class that reindexes given survey by `index_cols` and allows for plotting gathers by their
+    indices. Does not implement any calculation logic."""
     def __init__(self, name=None):
         super().__init__(name=name)
 
@@ -15,13 +15,13 @@ class SurveyAttribute(Metric):
         self.survey = None
 
     def bind_context(self, metric_map, survey):
-        """Process metric evaluation context: memorize the parent survey, reindexed by `coords_cols`."""
-        self.survey = survey.reindex(metric_map.coords_cols)
+        """Process metric evaluation context: memorize the parent survey, reindexed by `index_cols`."""
+        self.survey = survey.reindex(metric_map.index_cols)
 
     def plot(self, ax, coords, index, sort_by=None, **kwargs):
-        """Plot a gather by given `coords`. Optionally sort it."""
-        _ = index
-        gather = self.survey.get_gather(coords)
+        """Plot a gather by its `index`. Optionally sort it."""
+        _ = coords
+        gather = self.survey.get_gather(index)
         if sort_by is not None:
             gather = gather.sort(by=sort_by)
         gather.plot(ax=ax, **kwargs)

--- a/seismicpro/survey/plot_geometry.py
+++ b/seismicpro/survey/plot_geometry.py
@@ -77,69 +77,72 @@ class SurveyGeometryPlot(PairedPlot):  # pylint: disable=too-many-instance-attri
 
     @property
     def is_shot_view(self):
-        """bool: whether the current view displays shot locations."""
+        """bool: Whether the current view displays shot locations."""
         return self.main.current_view == 0
 
     @property
     def active_map(self):
+        """MetricMap: Fold map of sources or receivers depending on the current view."""
         return self.source_map if self.is_shot_view else self.receiver_map
 
     @property
     def survey(self):
-        """Survey: a survey to get gathers from, depends on the current view."""
+        """Survey: A survey to get gathers from, depends on the current view."""
         return self.source_survey if self.is_shot_view else self.receiver_survey
 
     @property
     def coords(self):
-        """np.ndarray: Coordinates of shots or receivers, depend on the current view."""
+        """np.ndarray: Coordinates of sources or receivers depending on the current view."""
         return self.source_coords if self.is_shot_view else self.receiver_coords
 
     @property
     def coords_neighbors(self):
-        """sklearn.neighbors.NearestNeighbors: nearest neighbors of shots or receivers, depend on the current view."""
+        """sklearn.neighbors.NearestNeighbors: Nearest neighbors of sources or receivers depending on the current
+        view."""
         return self.source_neighbors if self.is_shot_view else self.receiver_neighbors
-    
+
     @property
     def sort_by(self):
+        """str or list of str: Gather sorting depending on the current view."""
         return self.source_sort_by if self.is_shot_view else self.receiver_sort_by
 
     @property
     def activated_coords_cols(self):
-        """list of 2 str: coordinates columns, describing highlighted objects, depend on the current view."""
+        """list of 2 str: Coordinates columns describing highlighted objects depending on the current view."""
         return ["GroupX", "GroupY"] if self.is_shot_view else ["SourceX", "SourceY"]
 
     @property
     def main_color(self):
-        """str: color of the plotted objects, depends on the current view."""
+        """str: Color of the plotted objects depending on the current view."""
         return "tab:red" if self.is_shot_view else "tab:blue"
 
     @property
     def main_marker(self):
-        """str: marker of the plotted objects, depends on the current view."""
+        """str: Marker of the plotted objects depending on the current view."""
         return "*" if self.is_shot_view else "v"
 
     @property
     def aux_color(self):
-        """str: color of the highlighted objects, depends on the current view."""
+        """str: Color of the highlighted objects depending on the current view."""
         return "tab:blue" if self.is_shot_view else "tab:red"
 
     @property
     def aux_marker(self):
-        """str: marker of the highlighted objects, depends on the current view."""
+        """str: Marker of the highlighted objects depending on the current view."""
         return "v" if self.is_shot_view else "*"
 
     @property
     def map_x_label(self):
-        """str: label of the x map axis, depends on the current view."""
+        """str: Label of the X map axis depending on the current view."""
         return "SourceX" if self.is_shot_view else "GroupX"
 
     @property
     def map_y_label(self):
-        """str: label of the y map axis, depends on the current view."""
+        """str: Label of the Y map axis depending on the current view."""
         return "SourceY" if self.is_shot_view else "GroupY"
 
     def _plot_map(self, ax, contours, keep_aspect, x_lim, y_lim, x_ticker, y_ticker, **kwargs):
-        """Plot shot or receiver locations depending on the current view."""
+        """Plot locations of sources or receivers depending on the current view."""
         self.aux.clear()
         self.aux.box.layout.visibility = "hidden"
 
@@ -156,6 +159,7 @@ class SurveyGeometryPlot(PairedPlot):  # pylint: disable=too-many-instance-attri
         set_ticks(ax, "y", self.map_y_label, **y_ticker)
 
     def _plot_gather(self, ax, coords, index, **kwargs):
+        """Display a gather with given index and highlight locations of activated sources or receivers."""
         _ = coords
         gather = self.survey.get_gather(index)
         if self.sort_by is not None:
@@ -164,6 +168,7 @@ class SurveyGeometryPlot(PairedPlot):  # pylint: disable=too-many-instance-attri
         self._plot_activated(gather[self.activated_coords_cols])
 
     def _plot_activated(self, coords):
+        """Highlight locations of activated sources or receivers."""
         if self.activated_scatter is not None:
             self.activated_scatter.remove()
         self.activated_scatter = self.main.ax.scatter(*coords.T, color=self.aux_color, marker=self.aux_marker,
@@ -171,7 +176,8 @@ class SurveyGeometryPlot(PairedPlot):  # pylint: disable=too-many-instance-attri
         self.main.fig.canvas.draw_idle()
 
     def click(self, coords):
-        """Highlight activated shot or receiver locations and display a gather."""
+        """Process a click on the map: display the selected gather and highlight locations of activated sources or
+        receivers."""
         coords = tuple(self.coords[self.coords_neighbors.kneighbors([coords], return_distance=False).item()])
         gather_indices = self.active_map.get_indices_by_map_coords(coords).index.tolist()
         gather_coords = [coords] * len(gather_indices)
@@ -181,7 +187,7 @@ class SurveyGeometryPlot(PairedPlot):  # pylint: disable=too-many-instance-attri
         return coords
 
     def unclick(self):
-        """Remove highlighted shot or receiver locations and hide the gather plot."""
+        """Remove highlighted locations of sources or receivers, clear the gather plot and hide it."""
         if self.activated_scatter is not None:
             self.activated_scatter.remove()
             self.activated_scatter = None

--- a/seismicpro/survey/survey.py
+++ b/seismicpro/survey/survey.py
@@ -396,17 +396,22 @@ class Survey(GatherContainer, SamplesContainer):  # pylint: disable=too-many-ins
     def __str__(self):
         """Print survey metadata including information about the source file, field geometry if it was inferred and
         trace statistics if they were calculated."""
+        source_id_str = ", ".join(to_list(self.source_id_cols)) if self.source_id_cols is not None else "Unknown"
+        receiver_id_str = ", ".join(to_list(self.receiver_id_cols)) if self.receiver_id_cols is not None else "Unknown"
         offsets = self.headers.get('offset')
-        offset_range = f'[{np.min(offsets)} m, {np.max(offsets)} m]' if offsets is not None else "Unknown"
+        offset_range = f"[{np.min(offsets)} m, {np.max(offsets)} m]" if offsets is not None else "Unknown"
+
         msg = f"""
         Survey path:               {self.path}
         Survey name:               {self.name}
         Survey size:               {os.path.getsize(self.path) / (1024**3):4.3f} GB
 
-        Indexed by:                {', '.join(to_list(self.indexed_by))}
-        Number of gathers:         {self.n_gathers}
+        Source ID headers:         {source_id_str}
         Number of sources:         {get_first_defined(self.n_sources, "Unknown")}
+        Receiver ID headers:       {receiver_id_str}
         Number of receivers:       {get_first_defined(self.n_receivers, "Unknown")}
+        Indexed by:                {", ".join(to_list(self.indexed_by))}
+        Number of gathers:         {self.n_gathers}
         Number of traces:          {self.n_traces}
         Trace length:              {self.n_samples} samples
         Sample rate:               {self.sample_rate} ms

--- a/seismicpro/survey/survey.py
+++ b/seismicpro/survey/survey.py
@@ -454,7 +454,7 @@ class Survey(GatherContainer, SamplesContainer):  # pylint: disable=too-many-ins
         if validate:
             headers = self.headers.copy(deep=False)
             headers.reset_index(inplace=True)
-            validate_source_headers(self.headers, cols)
+            validate_source_headers(headers, cols)
         self.source_id_cols = cols
 
     def set_receiver_id_cols(self, cols, validate=True):
@@ -463,7 +463,7 @@ class Survey(GatherContainer, SamplesContainer):  # pylint: disable=too-many-ins
         if validate:
             headers = self.headers.copy(deep=False)
             headers.reset_index(inplace=True)
-            validate_receiver_headers(self.headers, cols)
+            validate_receiver_headers(headers, cols)
         self.receiver_id_cols = cols
 
     def validate_headers(self, offset_atol=10, cdp_atol=10, elevation_atol=5, elevation_radius=50):

--- a/seismicpro/survey/survey.py
+++ b/seismicpro/survey/survey.py
@@ -182,7 +182,6 @@ class Survey(GatherContainer, SamplesContainer):  # pylint: disable=too-many-ins
         # Forbid loading UnassignedInt1 and UnassignedInt2 headers since they are treated differently from all other
         # headers by `segyio`
         allowed_headers = set(segyio.tracefield.keys.keys()) - {"UnassignedInt1", "UnassignedInt2"}
-
         header_index = to_list(header_index)
         if header_cols is None:
             header_cols = set()
@@ -198,12 +197,16 @@ class Survey(GatherContainer, SamplesContainer):  # pylint: disable=too-many-ins
                 source_id_cols = "FieldRecord"
             elif {"SourceX", "SourceY"} <= headers_to_load:
                 source_id_cols = ["SourceX", "SourceY"]
+        else:
+            headers_to_load |= set(to_list(source_id_cols))
         self.source_id_cols = source_id_cols
+
         if receiver_id_cols is None:
             if {"GroupX", "GroupY"} <= headers_to_load:
-                source_id_cols = ["GroupX", "GroupY"]
+                receiver_id_cols = ["GroupX", "GroupY"]
+        else:
+            headers_to_load |= set(to_list(receiver_id_cols))
         self.receiver_id_cols = receiver_id_cols
-        headers_to_load = headers_to_load | set(to_list(source_id_cols)) | set(to_list(receiver_id_cols))
 
         # TRACE_SEQUENCE_FILE is not loaded but reconstructed manually since sometimes it is undefined in the file but
         # we rely on it during gather loading

--- a/seismicpro/survey/survey.py
+++ b/seismicpro/survey/survey.py
@@ -1316,7 +1316,7 @@ class Survey(GatherContainer, SamplesContainer):  # pylint: disable=too-many-ins
         index_cols, coords_cols = by_to_cols.get(by.lower())
         if coords_cols is None:
             raise ValueError(f"by must be one of {', '.join(by_to_cols.keys())} but {by} given.")
-        index_cols = get_first_defined(index_cols, id_cols)
+        index_cols = get_first_defined(id_cols, index_cols)
 
         metric_data = self.get_headers(coords_cols)
         if index_cols is not None:
@@ -1397,7 +1397,7 @@ class Survey(GatherContainer, SamplesContainer):  # pylint: disable=too-many-ins
         fold_map : BaseMetricMap
             Constructed fold map.
         """
-        tmp_map = self._construct_map(np.ones(len(self)), name="fold", by=by, id_cols=id_cols, agg="sum")
+        tmp_map = self._construct_map(np.ones(self.n_traces), name="fold", by=by, id_cols=id_cols, agg="sum")
         metric = tmp_map.metric
         index = tmp_map.index_data[tmp_map.index_cols]
         coords = tmp_map.index_data[tmp_map.coords_cols]

--- a/seismicpro/survey/survey.py
+++ b/seismicpro/survey/survey.py
@@ -734,7 +734,7 @@ class Survey(GatherContainer, SamplesContainer):  # pylint: disable=too-many-ins
         ValueError
             If survey geometry was not inferred.
         """
-        if self.geographic_contours is None:
+        if not self.has_inferred_geometry:
             raise ValueError("Survey geometry was not inferred, call `infer_geometry` method first.")
         return self._dist_to_contours(coords, self.geographic_contours)
 
@@ -763,7 +763,7 @@ class Survey(GatherContainer, SamplesContainer):  # pylint: disable=too-many-ins
         ValueError
             If properties of survey binning were not inferred.
         """
-        if self.bin_contours is None:
+        if not self.has_inferred_binning:
             raise ValueError("Properties of survey binning were not inferred, call `infer_binning` method first.")
         return self._dist_to_contours(bins, self.bin_contours)
 
@@ -1277,10 +1277,13 @@ class Survey(GatherContainer, SamplesContainer):  # pylint: disable=too-many-ins
         """
         line_cols = ["INLINE_3D", "CROSSLINE_3D"]
         super_line_cols = ["SUPERGATHER_INLINE_3D", "SUPERGATHER_CROSSLINE_3D"]
-        if not self.has_inferred_binning:
-            raise KeyError("INLINE_3D and CROSSLINE_3D headers must be loaded")
         if set(super_line_cols) <= self.available_headers:
             raise ValueError("Supergathers have already been generated")
+        if not self.has_inferred_binning:
+            if set(line_cols) <= self.available_headers:
+                self.infer_binning()
+            else:
+                raise KeyError("INLINE_3D and CROSSLINE_3D headers must be loaded")
 
         self = maybe_copy(self, inplace, ignore="headers")  # pylint: disable=self-cls-assignment
         size = np.broadcast_to(size, 2)
@@ -1430,7 +1433,9 @@ class Survey(GatherContainer, SamplesContainer):  # pylint: disable=too-many-ins
         by : {"source", "shot", "receiver", "rec", "cdp", "cmp", "midpoint", "bin", "supergather"}
             Gather type to aggregate header values over.
         id_cols : str or list of str, optional
-            Trace headers that uniquely identify a gather of the chosen type. Acts as an index of the resulting map.
+            Trace headers that uniquely identify a gather of the chosen type. Acts as an index of the resulting map. If
+            not given and `by` represents either a common source or common receiver gather, `self.source_id_cols` or
+            `self.receiver_id_cols` are used respectively.
         drop_duplicates : bool, optional, defaults to False
             Whether to drop duplicated entries of (index, coordinates, metric value). Useful when dealing with a header
             defined for a shot or receiver, not a trace (e.g. constructing a map of elevations by shots).
@@ -1463,7 +1468,9 @@ class Survey(GatherContainer, SamplesContainer):  # pylint: disable=too-many-ins
         by : {"source", "shot", "receiver", "rec", "cdp", "cmp", "midpoint", "bin", "supergather"}
             Gather type to aggregate header values over.
         id_cols : str or list of str, optional
-            Trace headers that uniquely identify a gather of the chosen type. Acts as an index of the resulting map.
+            Trace headers that uniquely identify a gather of the chosen type. Acts as an index of the resulting map. If
+            not given and `by` represents either a common source or common receiver gather, `self.source_id_cols` or
+            `self.receiver_id_cols` are used respectively.
         agg : str or callable, optional, defaults to "mean"
             An aggregation function. Passed directly to `pandas.core.groupby.DataFrameGroupBy.agg`.
         bin_size : int, float or array-like with length 2, optional

--- a/seismicpro/survey/survey.py
+++ b/seismicpro/survey/survey.py
@@ -1302,6 +1302,7 @@ class Survey(GatherContainer, SamplesContainer):  # pylint: disable=too-many-ins
         SurveyGeometryPlot(self, **kwargs).plot()
 
     def _construct_map(self, values, name, by, id_cols=None, drop_duplicates=False, agg=None, bin_size=None):
+        """Construct a metric map of `values` aggregated by gather, whose type is defined by `by`."""
         by_to_cols = {
             "source": (self.source_id_cols, ["SourceX", "SourceY"]),
             "shot": (self.source_id_cols, ["SourceX", "SourceY"]),

--- a/seismicpro/survey/survey.py
+++ b/seismicpro/survey/survey.py
@@ -1302,18 +1302,29 @@ class Survey(GatherContainer, SamplesContainer):  # pylint: disable=too-many-ins
             Whether to display a field contour if survey geometry was inferred.
         keep_aspect : bool, optional, defaults to False
             Whether to keep aspect ratio of the map plot.
+        source_id_cols : str or list of str, optional
+            Trace headers that uniquely identify a seismic source. If not given, `self.source_id_cols` is used.
+        source_sort_by : str or list of str, optional
+            Header names to sort the displayed common source gathers by. If not given, passed `sort_by` value is used.
+        receiver_id_cols : str or list of str, optional
+            Trace headers that uniquely identify a receiver. If not given, `self.receiver_id_cols` is used.
+        receiver_sort_by : str or list of str, optional
+            Header names to sort the displayed common receiver gathers by. If not given, passed `sort_by` value is
+            used.
+        sort_by : str or list of str, optional
+            Default header names to sort the displayed gather by. If not given, no sorting is performed.
+        gather_plot_kwargs : dict, optional
+            Additional arguments to pass to `Gather.plot`.
         x_ticker : str or dict, optional
             Parameters to control `x` axis tick formatting and layout of the map plot. See `.utils.set_ticks` for more
             details.
         y_ticker : dict, optional
             Parameters to control `y` axis tick formatting and layout of the map plot. See `.utils.set_ticks` for more
             details.
-        sort_by : str, optional
-            Header name to sort the displayed gather by.
-        gather_plot_kwargs : dict, optional
-            Additional arguments to pass to `Gather.plot`.
         figsize : tuple with 2 elements, optional, defaults to (4.5, 4.5)
             Size of created map and gather figures. Measured in inches.
+        orientation : {"horizontal", "vertical"}, optional, defaults to "horizontal"
+            Defines whether to stack the main and auxiliary plots horizontally or vertically.
         kwargs : misc, optional
             Additional keyword arguments to pass to `matplotlib.axes.Axes.scatter` when plotting the map.
         """

--- a/seismicpro/survey/survey.py
+++ b/seismicpro/survey/survey.py
@@ -43,7 +43,7 @@ class Survey(GatherContainer, SamplesContainer):  # pylint: disable=too-many-ins
     - ['INLINE_3D', 'CROSSLINE_3D'] - to get common midpoint gathers.
 
     `header_cols` argument specifies all other trace headers to load to further be available in gather processing
-    pipelines. All loaded headers are stored in a `headers` attribute as a `pd.DataFrame` with `header_index` columns
+    pipelines. All loaded headers are stored in the `headers` attribute as a `pd.DataFrame` with `header_index` columns
     set as its index.
 
     Values of both `header_index` and `header_cols` must be any of those specified in
@@ -57,12 +57,18 @@ class Survey(GatherContainer, SamplesContainer):  # pylint: disable=too-many-ins
     If both of them are present and equal or only one of them is well-defined (non-zero), it is used as a sample rate.
     Otherwise, an error is raised.
 
-    If `INLINE_3D`, `CROSSLINE_3D`, `CDP_X` and `CDP_Y` trace headers are loaded, field geometry is automatically
-    inferred on survey construction which allows accessing:
-    - Some geometry-related attributes of a survey, such as `area`, `perimeter` and `bin_size`,
+    If `INLINE_3D` and `CROSSLINE_3D` trace headers are loaded, properties of survey binning are automatically inferred
+    on survey construction which allows accessing:
+    - Some bin-related attributes of the survey, such as `n_bins`,
+    - `dist_to_bin_contours` method which calculates distances from points to a contour of the survey in bin
+      coordinates.
+
+    If `CDP_X` and `CDP_Y` headers are loaded together with `INLINE_3D` and `CROSSLINE_3D`, field geometry is also
+    inferred which allows accessing:
+    - Some geometry-related attributes of the survey, such as `area`, `perimeter` and `bin_size`,
     - `coords_to_bins` and `bins_to_coords` methods which convert geographic coordinates to bins and back respectively,
-    - `dist_to_bin_contours` and `dist_to_geographic_contours` methods which calculate distances from points to a
-      contour of the survey in bin and geographic coordinates respectively.
+    - `dist_to_geographic_contours` method which calculates distances from points to a contour of the survey in
+      geographic coordinates.
 
     Examples
     --------
@@ -146,15 +152,26 @@ class Survey(GatherContainer, SamplesContainer):  # pylint: disable=too-many-ins
         Interpolator of trace values quantiles. `None` until trace statistics are calculated.
     n_dead_traces : int or None
         The number of traces with constant value (dead traces). `None` until `mark_dead_traces` method is called.
+    has_inferred_binning : bool
+        Whether properties of survey binning have been inferred. `True` if `INLINE_3D` and `CROSSLINE_3D` trace headers
+        are loaded on survey instantiation or `infer_binning` method is explicitly called.
+    n_bins : int or None
+        The number of bins in the survey. `None` until properties of survey binning are inferred.
+    is_stacked : bool or None
+        Whether the survey is stacked. `None` until properties of survey binning are inferred.
+    field_mask : 2d np.ndarray or None
+        A binary mask of the field with ones set for bins with at least one trace and zeros otherwise. `None` until
+        properties of survey binning are inferred.
+    field_mask_origin : np.ndarray with 2 elements
+        Minimum values of inline and crossline over the field. `None` until properties of survey binning are inferred.
+    bin_contours : tuple of np.ndarray or None
+        Contours of all connected components of the field in bin coordinates. `None` until properties of survey binning
+        are inferred.
     has_inferred_geometry : bool
         Whether the survey has inferred geometry. `True` if `INLINE_3D`, `CROSSLINE_3D`, `CDP_X` and `CDP_Y` trace
         headers are loaded on survey instantiation or `infer_geometry` method is explicitly called.
     is_2d : bool or None
         Whether the survey is 2D. `None` until survey geometry is inferred.
-    is_stacked : bool or None
-        Whether the survey is stacked. `None` until survey geometry is inferred.
-    n_bins : int or None
-        The number of bins in the survey. `None` until survey geometry is inferred.
     bin_size : np.ndarray with 2 elements or None
         Bin sizes in meters along inline and crossline directions. `None` until survey geometry is inferred.
     inline_length : float or None
@@ -165,8 +182,6 @@ class Survey(GatherContainer, SamplesContainer):  # pylint: disable=too-many-ins
         Field area in squared meters. `None` until survey geometry is inferred.
     perimeter : float or None
         Field perimeter in meters. `None` until survey geometry is inferred.
-    bin_contours : tuple of np.ndarray or None
-        Contours of all connected components of the field in bin coordinates. `None` until survey geometry is inferred.
     geographic_contours : tuple of np.ndarray or None
         Contours of all connected components of the field in geographic coordinates. `None` until survey geometry is
         inferred.
@@ -293,20 +308,27 @@ class Survey(GatherContainer, SamplesContainer):  # pylint: disable=too-many-ins
         self.quantile_interpolator = None
         self.n_dead_traces = None
 
+        # Define all bin-related attributes and automatically infer them if both INLINE_3D and CROSSLINE_3D are loaded
+        self.has_inferred_binning = False
+        self.n_bins = None
+        self.is_stacked = None
+        self.field_mask = None
+        self.field_mask_origin = None
+        self.bin_contours = None
+        if {"INLINE_3D", "CROSSLINE_3D"} <= headers_to_load:
+            self.infer_binning()
+
         # Define all geometry-related attributes and automatically infer field geometry if required headers are loaded
         self.has_inferred_geometry = False
         self._bins_to_coords_reg = None
         self._coords_to_bins_reg = None
-        self.n_bins = None
-        self.is_stacked = None
-        self.bin_size = None  # m
-        self.inline_length = None  # m
-        self.crossline_length = None  # m
+        self.is_2d = None
         self.area = None  # m^2
         self.perimeter = None  # m
-        self.bin_contours = None
+        self.bin_size = None  # (m, m)
+        self.inline_length = None  # m
+        self.crossline_length = None  # m
         self.geographic_contours = None
-        self.is_2d = None
         if {"INLINE_3D", "CROSSLINE_3D", "CDP_X", "CDP_Y"} <= headers_to_load:
             self.infer_geometry()
 
@@ -396,8 +418,6 @@ class Survey(GatherContainer, SamplesContainer):  # pylint: disable=too-many-ins
     def __str__(self):
         """Print survey metadata including information about the source file, field geometry if it was inferred and
         trace statistics if they were calculated."""
-        source_id_str = ", ".join(to_list(self.source_id_cols)) if self.source_id_cols is not None else "Unknown"
-        receiver_id_str = ", ".join(to_list(self.receiver_id_cols)) if self.receiver_id_cols is not None else "Unknown"
         offsets = self.headers.get('offset')
         offset_range = f"[{np.min(offsets)} m, {np.max(offsets)} m]" if offsets is not None else "Unknown"
 
@@ -406,26 +426,45 @@ class Survey(GatherContainer, SamplesContainer):  # pylint: disable=too-many-ins
         Survey name:               {self.name}
         Survey size:               {os.path.getsize(self.path) / (1024**3):4.3f} GB
 
-        Source ID headers:         {source_id_str}
-        Number of sources:         {get_first_defined(self.n_sources, "Unknown")}
-        Receiver ID headers:       {receiver_id_str}
-        Number of receivers:       {get_first_defined(self.n_receivers, "Unknown")}
-        Indexed by:                {", ".join(to_list(self.indexed_by))}
-        Number of gathers:         {self.n_gathers}
         Number of traces:          {self.n_traces}
         Trace length:              {self.n_samples} samples
         Sample rate:               {self.sample_rate} ms
         Times range:               [{min(self.samples)} ms, {max(self.samples)} ms]
         Offsets range:             {offset_range}
         Is uphole:                 {get_first_defined(self.is_uphole, "Unknown")}
+
+        Indexed by:                {", ".join(to_list(self.indexed_by))}
+        Number of gathers:         {self.n_gathers}
+        Mean gather fold:          {int(self.n_traces / self.n_gathers)}
+        """
+
+        if self.has_inferred_binning:
+            msg += f"""
+        Is stacked:                {self.is_stacked}
+        Number of bins:            {self.n_bins}
+        Mean bin fold:             {int(self.n_traces / self.n_bins)}
+        """
+
+        if self.source_id_cols is not None:
+            n_sources = self.n_sources  # Run possibly time-consuming calculation once
+            msg += f"""
+        Source ID headers:         {", ".join(to_list(self.source_id_cols))}
+        Number of sources:         {n_sources}
+        Mean source fold:          {int(self.n_traces / n_sources)}
+        """
+
+        if self.receiver_id_cols is not None:
+            n_receivers = self.n_receivers  # Run possibly time-consuming calculation once
+            msg += f"""
+        Receiver ID headers:       {", ".join(to_list(self.receiver_id_cols))}
+        Number of receivers:       {n_receivers}
+        Mean receiver fold:        {int(self.n_traces / n_receivers)}
         """
 
         if self.has_inferred_geometry:
             msg += f"""
         Field geometry:
         Dimensionality:            {"2D" if self.is_2d else "3D"}
-        Is stacked:                {self.is_stacked}
-        Number of bins:            {self.n_bins}
         Area:                      {(self.area / 1000**2):.2f} km^2
         Perimeter:                 {(self.perimeter / 1000):.2f} km
         Inline bin size:           {self.bin_size[0]:.1f} m
@@ -526,9 +565,16 @@ class Survey(GatherContainer, SamplesContainer):  # pylint: disable=too-many-ins
     #                        Geometry-related methods                        #
     #------------------------------------------------------------------------#
 
-    def _get_field_mask(self):
-        """Get a binary mask of the field with ones set for bins with at least one trace and zeros otherwise. Mask
-        origin corresponds to a bin with minimum inline and crossline over the field and is also returned."""
+    def infer_binning(self):
+        """Infer properties of survey binning by estimating the following entities:
+        1. Number of bins,
+        2. Pre- or post-stack flag,
+        3. Binary mask of the field and its origin,
+        4. Field contours in bin coordinate system.
+
+        After the method is executed `has_inferred_binning` flag is set to `True` and all the calculated values can be
+        obtained via corresponding attributes.
+        """
         # Find unique pairs of inlines and crosslines, drop_duplicates is way faster than np.unique
         lines = self.get_headers(["INLINE_3D", "CROSSLINE_3D"]).drop_duplicates().to_numpy()
 
@@ -538,61 +584,55 @@ class Survey(GatherContainer, SamplesContainer):  # pylint: disable=too-many-ins
         normed_lines = lines - origin
         field_mask = np.zeros(normed_lines.max(axis=0) + 1, dtype=np.uint8)
         field_mask[normed_lines[:, 0], normed_lines[:, 1]] = 1
-        return field_mask, origin
+        bin_contours = cv2.findContours(field_mask.T, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE, offset=origin)[0]
+
+        # Set all bin-related attributes
+        self.has_inferred_binning = True
+        self.n_bins = len(lines)
+        self.is_stacked = self.n_traces == self.n_bins
+        self.field_mask = field_mask
+        self.field_mask_origin = origin
+        self.bin_contours = bin_contours
 
     def infer_geometry(self):
         """Infer survey geometry by estimating the following entities:
         1. Survey dimensionality (2D/3D),
-        2. Pre- or post-stack flag,
-        3. Number of bins and bin size,
-        4. Lengths along inline and crossline directions,
-        5. Area and perimeter,
-        6. Field contours in geographic and bin coordinate systems,
-        7. Mappings from geographic coordinates to bins and back.
+        2. Bin sizes along inline and crossline directions,
+        3. Survey lengths along inline and crossline directions,
+        4. Survey area and perimeter,
+        5. Field contours in geographic coordinate system,
+        6. Mappings from geographic coordinates to bins and back.
 
         After the method is executed `has_inferred_geometry` flag is set to `True` and all the calculated values can be
         obtained via corresponding attributes.
-
-        Returns
-        -------
-        survey : Survey
-            The survey with inferred geometry. Sets `has_inferred_geometry` flag to `True` and updates geometry-related
-            attributes inplace.
         """
         coords_cols = ["CDP_X", "CDP_Y"]
         bins_cols = ["INLINE_3D", "CROSSLINE_3D"]
-        cols = coords_cols + bins_cols
 
         # Construct a mapping from bins to their coordinates and back
-        bins_to_coords = self.get_headers(cols)
+        bins_to_coords = self.get_headers(coords_cols + bins_cols)
         bins_to_coords = bins_to_coords.groupby(bins_cols, sort=False, as_index=False).agg("mean")
         bins_to_coords_reg = LinearRegression(copy_X=False, n_jobs=-1)
-        bins_to_coords_reg.fit(bins_to_coords[bins_cols], bins_to_coords[coords_cols])
+        bins_to_coords_reg.fit(bins_to_coords[bins_cols].to_numpy(), bins_to_coords[coords_cols].to_numpy())
         coords_to_bins_reg = LinearRegression(copy_X=False, n_jobs=-1)
-        coords_to_bins_reg.fit(bins_to_coords[coords_cols], bins_to_coords[bins_cols])
+        coords_to_bins_reg.fit(bins_to_coords[coords_cols].to_numpy(), bins_to_coords[bins_cols].to_numpy())
 
-        # Compute field contour
-        field_mask, origin = self._get_field_mask()
-        bin_contours = cv2.findContours(field_mask.T, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE, offset=origin)[0]
+        # Compute geographic field contour
         geographic_contours = tuple(bins_to_coords_reg.predict(contour[:, 0])[:, None].astype(np.float32)
-                                    for contour in bin_contours)
+                                    for contour in self.bin_contours)
         perimeter = sum(cv2.arcLength(contour, closed=True) for contour in geographic_contours)
 
         # Set all geometry-related attributes
         self.has_inferred_geometry = True
         self._bins_to_coords_reg = bins_to_coords_reg
         self._coords_to_bins_reg = coords_to_bins_reg
-        self.n_bins = len(bins_to_coords)
-        self.is_stacked = self.n_traces == self.n_bins
         self.bin_size = np.diag(sp.linalg.polar(bins_to_coords_reg.coef_)[1])
         self.inline_length = (np.ptp(bins_to_coords["INLINE_3D"]) + 1) * self.bin_size[0]
         self.crossline_length = (np.ptp(bins_to_coords["CROSSLINE_3D"]) + 1) * self.bin_size[1]
         self.area = self.n_bins * np.prod(self.bin_size)
         self.perimeter = perimeter
-        self.bin_contours = bin_contours
         self.geographic_contours = geographic_contours
         self.is_2d = np.isclose(self.area, 0)
-        return self
 
     @staticmethod
     def _cast_coords(coords, transformer):
@@ -658,8 +698,6 @@ class Survey(GatherContainer, SamplesContainer):  # pylint: disable=too-many-ins
     @staticmethod
     def _dist_to_contours(coords, contours):
         """Calculate minimum signed distance from points in `coords` to each contour in `contours`."""
-        if contours is None:
-            raise ValueError("Survey geometry was not inferred, call `infer_geometry` method first.")
         coords = np.array(coords, dtype=np.float32)
         is_coords_1d = coords.ndim == 1
         coords = np.atleast_2d(coords)
@@ -696,6 +734,8 @@ class Survey(GatherContainer, SamplesContainer):  # pylint: disable=too-many-ins
         ValueError
             If survey geometry was not inferred.
         """
+        if self.geographic_contours is None:
+            raise ValueError("Survey geometry was not inferred, call `infer_geometry` method first.")
         return self._dist_to_contours(coords, self.geographic_contours)
 
     def dist_to_bin_contours(self, bins):
@@ -705,7 +745,7 @@ class Survey(GatherContainer, SamplesContainer):  # pylint: disable=too-many-ins
 
         Notes
         -----
-        Before calling this method, survey geometry must be inferred using :func:`~Survey.infer_geometry`.
+        Before calling this method, properties of survey binning must be inferred using :func:`~Survey.infer_binning`.
 
         Parameters
         ----------
@@ -721,8 +761,10 @@ class Survey(GatherContainer, SamplesContainer):  # pylint: disable=too-many-ins
         Raises
         ------
         ValueError
-            If survey geometry was not inferred.
+            If properties of survey binning were not inferred.
         """
+        if self.bin_contours is None:
+            raise ValueError("Properties of survey binning were not inferred, call `infer_binning` method first.")
         return self._dist_to_contours(bins, self.bin_contours)
 
     #------------------------------------------------------------------------#
@@ -1230,18 +1272,24 @@ class Survey(GatherContainer, SamplesContainer):  # pylint: disable=too-many-ins
         ------
         KeyError
             If `INLINE_3D` and `CROSSLINE_3D` headers were not loaded.
+        ValueError
+            If supergathers have already been generated.
         """
+        line_cols = ["INLINE_3D", "CROSSLINE_3D"]
+        super_line_cols = ["SUPERGATHER_INLINE_3D", "SUPERGATHER_CROSSLINE_3D"]
+        if not self.has_inferred_binning:
+            raise KeyError("INLINE_3D and CROSSLINE_3D headers must be loaded")
+        if set(super_line_cols) <= self.available_headers:
+            raise ValueError("Supergathers have already been generated")
+
         self = maybe_copy(self, inplace, ignore="headers")  # pylint: disable=self-cls-assignment
         size = np.broadcast_to(size, 2)
         step = np.broadcast_to(step, 2)
-        line_cols = ["INLINE_3D", "CROSSLINE_3D"]
-        super_line_cols = ["SUPERGATHER_INLINE_3D", "SUPERGATHER_CROSSLINE_3D"]
 
         if centers is None:
-            # Construct a field mask and erode it according to border_indent and strict flag
-            field_mask, field_mask_origin = self._get_field_mask()
+            # Erode the field mask according to border_indent and strict flags
             kernel = cv2.getStructuringElement(cv2.MORPH_RECT, np.broadcast_to(border_indent, 2) * 2 + 1).T
-            field_mask = cv2.erode(field_mask, kernel, borderType=cv2.BORDER_CONSTANT, borderValue=0)
+            field_mask = cv2.erode(self.field_mask, kernel, borderType=cv2.BORDER_CONSTANT, borderValue=0)
             if strict:
                 kernel = cv2.getStructuringElement(cv2.MORPH_RECT, size).T
                 field_mask = cv2.erode(field_mask, kernel, borderType=cv2.BORDER_CONSTANT, borderValue=0)
@@ -1249,7 +1297,7 @@ class Survey(GatherContainer, SamplesContainer):  # pylint: disable=too-many-ins
 
             # Calculate origins of the supergather grid along inline and crossline directions
             if origin is not None:
-                origin_i, origin_x = (np.broadcast_to(origin, 2) - field_mask_origin) % step
+                origin_i, origin_x = (np.broadcast_to(origin, 2) - self.field_mask_origin) % step
             else:
                 origin_i = self._get_optimal_origin(field_mask.sum(axis=1), step[0])
                 origin_x = self._get_optimal_origin(field_mask.sum(axis=0), step[1])
@@ -1259,7 +1307,7 @@ class Survey(GatherContainer, SamplesContainer):  # pylint: disable=too-many-ins
             grid_x = np.arange(origin_x, field_mask.shape[1], step[1])
             centers = np.stack(np.meshgrid(grid_i, grid_x), -1).reshape(-1, 2)
             is_valid = field_mask[centers[:, 0], centers[:, 1]].astype(bool)
-            centers = centers[is_valid] + field_mask_origin
+            centers = centers[is_valid] + self.field_mask_origin
 
         centers = np.array(centers)
         if centers.ndim != 2 or centers.shape[1] != 2:

--- a/seismicpro/utils/coordinates.py
+++ b/seismicpro/utils/coordinates.py
@@ -28,13 +28,18 @@ INDEX_TO_COORDS = {
 INDEX_TO_COORDS = {frozenset(to_list(key)): val for key, val in INDEX_TO_COORDS.items()}
 
 
-def get_coords_cols(index_cols):
+def get_coords_cols(index_cols, source_id_cols=None, receiver_id_cols=None):
     """Return headers columns to get coordinates from depending on the type of headers index. See the mapping in
     `INDEX_TO_COORDS`."""
-    coords_cols = INDEX_TO_COORDS.get(frozenset(to_list(index_cols)))
-    if coords_cols is None:
-        raise KeyError(f"Unknown coordinates columns for {index_cols} index")
-    return coords_cols
+    index_cols = frozenset(to_list(index_cols))
+    coords_cols = INDEX_TO_COORDS.get(index_cols)
+    if coords_cols is not None:
+        return coords_cols
+    if source_id_cols is not None and index_cols == frozenset(to_list(source_id_cols)):
+        return ("SourceX", "SourceY")
+    if receiver_id_cols is not None and index_cols == frozenset(to_list(receiver_id_cols)):
+        return ("GroupX", "GroupY")
+    raise KeyError(f"Unknown coordinates columns for {index_cols} index")
 
 
 GEOGRAPHIC_COORDS = {("X", "Y"), ("SourceX", "SourceY"), ("GroupX", "GroupY"), ("CDP_X", "CDP_Y")}


### PR DESCRIPTION
- Two new survey attributes are introduced: `source_id_cols` and `receiver_id_cols`, which store names of trace headers that uniquely identify a seismic source or receiver respectively. They can be passed either directly to the `Survey.__init__` or subsequently using `set_source_id_cols` and `set_receiver_id_cols` methods.
- `n_sources` and `n_receivers` properties are also introduced. They are also printed in `info` (wow!)
- All survey plotters now account for these attributes (including `construct_fold_map`, `construct_header_map` and `plot_geometry`),
- Prettify validation of survey headers:
  - Some extra checks were added,
  - Now all checks return the number and fraction of "bad" traces/sources/receivers