### PR TITLE
Speed up cube stacking

### DIFF
--- a/seismicpro/__init__.py
+++ b/seismicpro/__init__.py
@@ -1,5 +1,6 @@
 """Core classes and functions of SeismicPro"""
 
+from .config import config
 from .dataset import SeismicDataset
 from .index import SeismicIndex
 from .batch import SeismicBatch

--- a/seismicpro/batch.py
+++ b/seismicpro/batch.py
@@ -9,6 +9,7 @@ import matplotlib.pyplot as plt
 from batchflow import save_data_to, Batch, DatasetIndex, NamedExpression
 from batchflow.decorators import action, inbatch_parallel
 
+from .config import config
 from .index import SeismicIndex
 from .gather import Gather, CroppedGather
 from .gather.utils.crop_utils import make_origins
@@ -69,6 +70,13 @@ class SeismicBatch(Batch):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._num_calculated_metrics = 0
+
+    def __getstate__(self):
+        state = super().__getstate__()
+        if config["enable_fast_pickling"]:
+            state["_dataset"] = None
+            state["pipeline"] = None
+        return state
 
     def init_component(self, *args, dst=None, **kwargs):
         """Create and preallocate new attributes with names listed in `dst` if they don't exist and return ordinal

--- a/seismicpro/batch.py
+++ b/seismicpro/batch.py
@@ -72,6 +72,8 @@ class SeismicBatch(Batch):
         self._num_calculated_metrics = 0
 
     def __getstate__(self):
+        """Create pickling state of a batch from its `__dict__`. Don't pickle `dataset` and `pipeline` if
+        `enable_fast_pickling` config option is set."""
         state = super().__getstate__()
         if config["enable_fast_pickling"]:
             state["_dataset"] = None

--- a/seismicpro/config.py
+++ b/seismicpro/config.py
@@ -27,7 +27,7 @@ Reset an option to its default value:
 >>> print(config)
 {'enable_fast_pickling': False}
 
-Temporary change given options within a context manager:
+Temporarily change given options within a context manager:
 >>> with config.use_options(enable_fast_pickling=True):
 >>>     print(config)
 >>> print(config)
@@ -69,7 +69,7 @@ class Config:
 
     @contextmanager
     def use_options(self, **options):
-        """Enter a context manager that temporary changes given options and reverts them back upon exit."""
+        """Enter a context manager that temporarily changes given options and reverts them back upon exit."""
         self.options.update(options)
         yield
         self.reset_options(*options.keys())

--- a/seismicpro/config.py
+++ b/seismicpro/config.py
@@ -28,7 +28,7 @@ class Config:
     def use_options(self, **kwargs):
         self.options.update(kwargs)
         yield
-        self.reset_options(kwargs.keys())
+        self.reset_options(*kwargs.keys())
 
 
 config = Config(_DEFAULT_CONFIG)

--- a/seismicpro/config.py
+++ b/seismicpro/config.py
@@ -1,0 +1,34 @@
+from contextlib import contextmanager
+
+
+_DEFAULT_CONFIG = {
+    "enable_fast_pickling": False,
+}
+
+
+class Config:
+    def __init__(self, options):
+        self.default_options = options.copy()
+        self.options = options.copy()
+
+    def __getitem__(self, key):
+        return self.options[key]
+
+    def __setitem__(self, key, value):
+        self.options[key] = value
+
+    def reset_options(self, *args):
+        for arg in args:
+            if arg in self.default_options:
+                self.options[arg] = self.default_options[arg]
+            else:
+                _ = self.options.pop(arg, None)
+
+    @contextmanager
+    def use_options(self, **kwargs):
+        self.options.update(kwargs)
+        yield
+        self.reset_options(kwargs.keys())
+
+
+config = Config(_DEFAULT_CONFIG)

--- a/seismicpro/config.py
+++ b/seismicpro/config.py
@@ -1,34 +1,78 @@
+"""Stores global `SeismicPro` configuration and provides an interface to interact with it.
+
+The following options are currently available:
+
+enable_fast_pickling : bool, defaults to False
+    If enabled, several objects such as `SeismicDataset` or `Survey` stop pickling their most memory-intensive
+    attributes such as `index` and `headers`. Allows for huge time and memory savings when running pipelines with `mpc`
+    prefetch.
+
+All options can be accessed and updated via `config` variable available directly from the global `seismicpro`
+namespace.
+
+Examples
+--------
+Display the current config state:
+>>> from seismicpro import config
+>>> print(config)
+{'enable_fast_pickling': False}
+
+Update config option globally:
+>>> config["enable_fast_pickling"] = True
+>>> print(config)
+{'enable_fast_pickling': True}
+
+Reset an option to its default value:
+>>> config.reset_options("enable_fast_pickling")
+>>> print(config)
+{'enable_fast_pickling': False}
+
+Temporary change given options within a context manager:
+>>> with config.use_options(enable_fast_pickling=True):
+>>>     print(config)
+>>> print(config)
+{'enable_fast_pickling': True}
+{'enable_fast_pickling': False}
+"""
+
 from contextlib import contextmanager
 
 
-_DEFAULT_CONFIG = {
-    "enable_fast_pickling": False,
-}
-
-
 class Config:
-    def __init__(self, options):
-        self.default_options = options.copy()
-        self.options = options.copy()
+    """Store global `SeismicPro` configuration and provide an interface to interact with it."""
 
-    def __getitem__(self, key):
-        return self.options[key]
+    def __init__(self):
+        self.default_options = {
+            "enable_fast_pickling": False,
+        }
+        self.options = self.default_options.copy()
 
-    def __setitem__(self, key, value):
-        self.options[key] = value
+    def __repr__(self):
+        """String representation of the current config state."""
+        return repr(self.options)
 
-    def reset_options(self, *args):
-        for arg in args:
-            if arg in self.default_options:
-                self.options[arg] = self.default_options[arg]
+    def __getitem__(self, option):
+        """Get current option value."""
+        return self.options[option]
+
+    def __setitem__(self, option, value):
+        """Set a new option value."""
+        self.options[option] = value
+
+    def reset_options(self, *options):
+        """Reset given options to their default values."""
+        for option in options:
+            if option in self.default_options:
+                self.options[option] = self.default_options[option]
             else:
-                _ = self.options.pop(arg, None)
+                _ = self.options.pop(option, None)
 
     @contextmanager
-    def use_options(self, **kwargs):
-        self.options.update(kwargs)
+    def use_options(self, **options):
+        """Enter a context manager that temporary changes given options and reverts them back upon exit."""
+        self.options.update(options)
         yield
-        self.reset_options(*kwargs.keys())
+        self.reset_options(*options.keys())
 
 
-config = Config(_DEFAULT_CONFIG)
+config = Config()

--- a/seismicpro/dataset.py
+++ b/seismicpro/dataset.py
@@ -6,6 +6,7 @@ from textwrap import dedent
 
 from batchflow import Dataset
 
+from .config import config
 from .batch import SeismicBatch
 from .index import SeismicIndex
 
@@ -105,6 +106,12 @@ class SeismicDataset(Dataset):
         # Correctly set index if it has already been split
         super().__init__(None, batch_class=batch_class)
         self.set_index(index)
+
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        if config["enable_fast_pickling"]:
+            state["_index"] = None
+        return state
 
     def __getattr__(self, name):
         """Redirect requests to undefined attributes and methods to the underlying index."""

--- a/seismicpro/dataset.py
+++ b/seismicpro/dataset.py
@@ -108,6 +108,8 @@ class SeismicDataset(Dataset):
         self.set_index(index)
 
     def __getstate__(self):
+        """Create pickling state of a dataset from its `__dict__`. Don't pickle `index` if `enable_fast_pickling`
+        config option is set."""
         state = self.__dict__.copy()
         if config["enable_fast_pickling"]:
             state["_index"] = None

--- a/seismicpro/gather/gather.py
+++ b/seismicpro/gather/gather.py
@@ -1063,33 +1063,25 @@ class Gather(TraceContainer, SamplesContainer):
     def stack(self, amplify_factor=0):
         """Stack a gather by calculating mean value of all non-nan amplitudes for each time over the offset axis.
 
-        The gather being stacked must contain traces from a single bin. The resulting gather will contain a single
-        trace with `headers` matching those of the first input trace.
+        The resulting gather will contain a single trace with `headers` matching those of the first input trace.
 
         Parameters
         ----------
         amplify_factor : float in range [0, 1], optional, defaults to 0
             Amplifying factor which affects the normalization of the sum of hodographs amplitudes.
-            The amplitudes sum is multiplied by amplify_factor/sqrt(N) + (1 - amplify_factor)/N, 
-            where N is the number of live(non muted) amplitudes. Acts as the coherency amplifier for long hodographs.
-            Note that in case amplify_factor=0 (default), sum of trace amplitudes is simply divided by N, 
-            so that stack amplitude is the average of ensemble amplitudes. Must be in [0, 1] range.
+            The amplitudes sum is multiplied by amplify_factor/sqrt(N) + (1 - amplify_factor)/N, where N is the number
+            of live (non muted) amplitudes. Acts as the coherency amplifier for long hodographs. Note that in case
+            amplify_factor=0 (default), sum of trace amplitudes is simply divided by N, so that stack amplitude is the
+            average of ensemble amplitudes. Must be in [0, 1] range.
 
         Returns
         -------
         gather : Gather
             Stacked gather.
         """
-        lines = self[["INLINE_3D", "CROSSLINE_3D"]]
-        if (lines != lines[0]).any():
-            raise ValueError("Only a single CDP gather can be stacked")
-
         amplify_factor = np.clip(amplify_factor, 0, 1)
-        # Preserve headers of the first trace of the gather being stacked
-        self.headers = self.headers.iloc[[0]]
-
-        self.data = stacked_amplitude(self.data, amplify_factor, abs=False)[0]
-        self.data = self.data.reshape(1, -1)
+        self.headers = self.headers.iloc[[0]]  # Preserve headers of the first trace of the gather being stacked
+        self.data = stacked_amplitude(self.data, amplify_factor, abs=False)[0].reshape(1, -1)
         return self
 
     def crop(self, origins, crop_shape, n_crops=1, stride=None, pad_mode='constant', **kwargs):

--- a/seismicpro/survey/survey.py
+++ b/seismicpro/survey/survey.py
@@ -720,7 +720,7 @@ class Survey(GatherContainer, SamplesContainer):  # pylint: disable=too-many-ins
 
     # pylint: disable-next=too-many-statements
     def collect_stats(self, indices=None, n_quantile_traces=100000, quantile_precision=2, limits=None,
-                      chunk_size=1000, n_workers=None, bar=True):
+                      chunk_size=10000, n_workers=None, bar=True):
         """Collect the following statistics by iterating over survey traces:
         1. Min and max amplitude,
         2. Mean amplitude and trace standard deviation,
@@ -806,6 +806,9 @@ class Survey(GatherContainer, SamplesContainer):  # pylint: disable=too-many-ins
                 quantile_traces_buffer[i] = chunk[chunk_quantile_mask].ravel()
             min_buffer[i], max_buffer[i], mean_buffer[i], var_buffer[i] = calculate_trace_stats(chunk.ravel())
             return len(chunk)
+
+        # Precompile njitted function to correctly initialize TBB from the main thread
+        _ = calculate_trace_stats(self.loader.load_traces([0], limits=limits).ravel())
 
         # Accumulate min, max, mean and var values of traces chunks
         bar_desc = f"Calculating statistics for traces in survey {self.name}"

--- a/seismicpro/survey/survey.py
+++ b/seismicpro/survey/survey.py
@@ -21,6 +21,7 @@ from .headers_checks import validate_trace_headers, validate_source_headers, val
 from .metrics import SurveyAttribute
 from .plot_geometry import SurveyGeometryPlot
 from .utils import calculate_trace_stats
+from ..config import config
 from ..gather import Gather
 from ..containers import GatherContainer, SamplesContainer
 from ..utils import to_list, maybe_copy, get_cols, get_first_defined
@@ -350,6 +351,13 @@ class Survey(GatherContainer, SamplesContainer):  # pylint: disable=too-many-ins
         GatherContainer.headers.fset(self, headers)
         htp_dtype = np.int32 if len(headers) < np.iinfo(np.int32).max else np.int64
         self.headers[HDR_TRACE_POS] = np.arange(self.n_traces, dtype=htp_dtype)
+
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        if config["enable_fast_pickling"]:
+            state["_headers"] = None
+            state["_indexer"] = None
+        return state
 
     def __str__(self):
         """Print survey metadata including information about the source file, field geometry if it was inferred and

--- a/seismicpro/survey/survey.py
+++ b/seismicpro/survey/survey.py
@@ -353,6 +353,8 @@ class Survey(GatherContainer, SamplesContainer):  # pylint: disable=too-many-ins
         self.headers[HDR_TRACE_POS] = np.arange(self.n_traces, dtype=htp_dtype)
 
     def __getstate__(self):
+        """Create pickling state of a survey from its `__dict__`. Don't pickle `headers` and `indexer` if
+        `enable_fast_pickling` config option is set."""
         state = self.__dict__.copy()
         if config["enable_fast_pickling"]:
             state["_headers"] = None


### PR DESCRIPTION
* Add a global `SeismicPro` config inspired by that of `pandas`, now it contains a single option `enable_fast_pickling`.
* If this option is enabled, several objects such as `SeismicDataset` or `Survey` stop pickling their most memory-intensive attributes such as `headers`.
* This allows for huge time and memory savings when running  pipelines with `mpc` prefetch. The most common case is seismic cube stacking pipeline.
* In order to speed it up even more, two more enhancements are introduced:
  * Implement `SeismicBatch.combine_gathers` method which combines gathers loaded from the same `Survey` into a single gather. This allows for more efficient `dump` since text and bin headers are stored only once (which especially matters when dumping a single stacked trace) and speeds up subsequent `aggregate_segys` by the factor of `batch_size` used.
  * `Gather.stack` method now does not check if all the traces are assigned to the same bin. This speeds up `stack` by ~30% since generally `INLINE_3D` and `CROSSLINE_3D` are used as headers index in stacking pipeline and selecting them from `headers` takes more time than selecting a column. Moreover, this allows to perform common source/receiver gather stacks which are sometimes used by geoscientists.


A template of cube stacking pipeline now may look as follows:
```python
survey = ...  # Create survey here and load statics
svf = ...  # Create or load a StackingVelocityField
stack_path = "./stack.sgy"

BATCH_SIZE = 512
PREFETCH = 8

dataset = SeismicDataset(survey)
batch_size = min(BATCH_SIZE, len(dataset))
prefetch = min(8, math.ceil(len(dataset) / batch_size) - 1)

with tempfile.TemporaryDirectory() as tmp_dir:
    stacking_pipeline = (dataset.pipeline()
        .load(src="raw", target="for")
        .apply_statics("Statics", src="raw")
        .bandpass_filter(src="raw", low=10, high=45)
        .apply_agc(src="raw", window_size=1000)
        .evaluate_field(svf, src="raw", dst="vel")
        .apply_nmo("vel", mute_crossover=False, max_stretch_factor=0.15, src="raw")
        .stack(src="raw", amplify_factor=0.8)
        .combine_gathers(src="raw")
        .dump(path=tmp_dir, retain_parent_segy_headers=False, src="raw")
        .discard_batch()
    )

    with config.use_options(enable_fast_pickling=True):
        stacking_pipeline.run(batch_size, n_epochs=1, shuffle=False, drop_last=False,
                              prefetch=prefetch, target="mpc", bar="n")
    aggregate_segys(in_paths=os.path.join(tmp_dir, "*"), out_path=stack_path)
```